### PR TITLE
chore(#1): 開発基盤セットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,40 +1,68 @@
-# Dependencies
-node_modules/
-.expo/
-vendor/
+# Flutter / Dart
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+build/
+pubspec.lock
+*.iml
+
+# iOS
+ios/Pods/
+ios/.symlinks/
+ios/Flutter/Flutter.framework
+ios/Flutter/Flutter.podspec
+ios/Flutter/Generated.xcconfig
+ios/Flutter/app.flx
+ios/Flutter/app.zip
+ios/Flutter/flutter_assets/
+ios/Flutter/App.framework
+ios/ServiceDefinitions.json
+ios/Runner/GeneratedPluginRegistrant.*
+
+# Android
+android/.gradle/
+android/captures/
+android/gradlew
+android/gradlew.bat
+android/local.properties
+android/**/GeneratedPluginRegistrant.java
+android/key.properties
+*.jks
 
 # Build
-build/
-dist/
 *.ipa
 *.apk
 *.aab
+dist/
 
 # Environment
 .env
 .env.local
 .env.production
+*.env
 
 # IDE
 .idea/
 .vscode/
 *.swp
 *.swo
+*.sublime-workspace
 
 # OS
 .DS_Store
 Thumbs.db
 
-# React Native / Expo
-*.jsbundle
-*.hbc
-
-# Flutter
-.dart_tool/
-.flutter-plugins
-.flutter-plugins-dependencies
-.packages
-pubspec.lock
-
 # Supabase
 supabase/.temp/
+supabase/.branches/
+supabase/.keys/
+
+# Coverage
+coverage/
+lcov.info
+
+# Generated
+*.g.dart
+*.freezed.dart
+*.mocks.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- プロジェクト設計ドキュメント一式 (MVP機能スコープ、UI/UX設計、システム設計、技術選定)
+- 技術選定最終決定: Flutter + Supabase (PostgreSQL)
+- CHANGELOG.md (Keep a Changelog 形式)
+- CLAUDE.md (プロジェクト固有の開発ルール)
+- GitHub Issue ラベル (feature, bug, chore, docs, refactor, test, P0-P2)
+- main ブランチ保護ルール (PR必須)
+- .gitignore を Flutter/iOS/Android/Supabase 向けに最適化

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# Himatch (ヒマッチ) - プロジェクト開発ルール
+
+## プロジェクト概要
+
+友達の空き時間を自動マッチング＆文脈付き提案する予定調整iOSアプリ。
+
+## 技術スタック
+
+- **フロントエンド**: Flutter (Dart) + Riverpod + go_router
+- **バックエンド**: Supabase (PostgreSQL 16) + Edge Functions
+- **リアルタイム**: Supabase Realtime
+- **オフライン**: Drift (SQLite)
+- **認証**: Supabase Auth (Apple / Google / LINE)
+- **通知**: FCM
+- **天気**: Open-Meteo (Phase 2)
+
+## 開発ルール（6原則）
+
+### 1. チケット駆動
+
+- 全作業は GitHub Issue 作成後に着手
+- ブランチ名: `feature/#<issue>-<description>` or `fix/#<issue>-<description>`
+
+### 2. チケット更新 + PR
+
+- 着手時・進捗時・完了時に Issue へコメント
+- 完了時は PR 作成（`Closes #<issue>` で紐付け）
+
+### 3. Claude Code レビュー
+
+- PR 作成後、Claude Code（ローカル）が `gh pr diff` でレビュー
+- approve / request-changes を `gh pr review` で投稿
+- approve 後にマージ
+
+### 4. CHANGELOG 更新
+
+- 毎回 CHANGELOG.md を更新（Keep a Changelog 形式）
+- [Unreleased] セクションに追記
+
+### 5. ローカル作業 + push
+
+- 作業ディレクトリ: `C:\Users\sanya\himatch`
+- 完了時に必ず `git push`
+- コミット: `<type>(#<issue>): <説明>`
+  - type: feat / fix / chore / docs / refactor / test
+
+### 6. 作業記録
+
+- Issue に何をしたか・何を考えたか・問題を記録
+- PR の description にも同様の情報を含める
+
+## コーディング規約
+
+- Dart: [Effective Dart](https://dart.dev/effective-dart) に準拠
+- ファイル名: snake_case
+- クラス名: PascalCase
+- 変数・関数名: camelCase
+- プライベートメンバー: _prefix
+- import順序: dart: → package: → relative
+
+## ディレクトリ構成（予定）
+
+```
+lib/
+├── main.dart
+├── app.dart
+├── core/           # 共通ユーティリティ、定数、テーマ
+├── features/       # 機能別モジュール
+│   ├── auth/
+│   ├── schedule/
+│   ├── group/
+│   └── suggestion/
+├── models/         # データモデル
+├── providers/      # Riverpod プロバイダー
+├── services/       # Supabase、FCM等の外部サービス
+└── widgets/        # 共通ウィジェット
+```
+
+## 重要ファイル
+
+- `docs/TECH_DECISION.md` - 技術選定の根拠
+- `docs/architecture.md` - システム設計（DBスキーマ、API、アルゴリズム）
+- `docs/mvp-scope.md` - MVP機能スコープ
+- `docs/ui-ux-design.md` - UI/UX設計


### PR DESCRIPTION
## Summary

Himatch の開発基盤を構築。チケット駆動開発・レビュー体制・リリース管理のルールを適用するための初期設定。

Closes #1

## 変更内容

- **CHANGELOG.md**: Keep a Changelog 形式で作成。初期エントリ（設計ドキュメント一式、技術選定）を記載
- **CLAUDE.md**: プロジェクト固有の開発ルール（6原則）、コーディング規約、ディレクトリ構成、技術スタック情報
- **.gitignore**: React Native/Expo の不要エントリを削除し、Flutter/iOS/Android/Supabase/Coverage/Generated 向けに最適化
- **GitHub ラベル**: feature, bug, chore, docs, refactor, test, P0-critical, P1-high, P2-medium
- **main ブランチ保護**: PR必須（直接push禁止）

## 設計判断

- CLAUDE.md をリポジトリルートに配置 → Claude Code が自動的に読み込み、開発ルールを強制
- ブランチ保護は `enforce_admins: false` → 管理者は緊急時にバイパス可能
- .gitignore に `*.g.dart`, `*.freezed.dart` を追加 → Drift/Freezed のコード生成ファイルを除外

## Test plan

- [x] ラベルが GitHub Issues に表示される
- [x] main ブランチが保護されている（この PR 自体がその証明）
- [x] CHANGELOG.md が正しい形式
- [x] CLAUDE.md が読み込み可能

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs- and ignore-file-only changes; no runtime code or production behavior is modified.
> 
> **Overview**
> Sets up the repo’s *development/process baseline* by adding `CLAUDE.md` with project-specific workflow rules (ticket-driven work, PR/review flow, commit conventions) and a planned directory structure.
> 
> Introduces `CHANGELOG.md` in Keep a Changelog format with an initial `[Unreleased]` entry documenting the baseline setup/decisions.
> 
> Reworks `.gitignore` to target Flutter/iOS/Android/Supabase development, adding ignores for generated/build artifacts, env files, coverage outputs, and removing prior React Native/Expo-specific entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24c6ef3eeb4546864be61dbd71123230e8c11c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->