### PR TITLE
feat(#5): データモデル実装 (Freezed v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ログイン画面スキャフォールド (Apple/Google/LINE ボタン配置)
 - コア定数・ユーティリティ (AppConstants, AppDateUtils)
 - 依存パッケージ: supabase_flutter, table_calendar, flutter_animate, freezed 等
+- データモデル (Freezed v3 + json_serializable): AppUser, Group, GroupMember, Schedule, Suggestion, ShiftPattern, AppNotification
+- スケジュール種別 (ScheduleType): shift/event/free/blocked
+- 文脈分類 (TimeCategory): morning/lunch/afternoon/evening/all_day
+- 天気情報モデル (WeatherSummary): 候補日の天気表示用
+- モデル単体テスト (10テスト: fromJson/toJson/copyWith/enum)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,8 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+analyzer:
+  errors:
+    invalid_annotation_target: ignore
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules: []

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -1,0 +1,37 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'group.freezed.dart';
+part 'group.g.dart';
+
+@freezed
+abstract class Group with _$Group {
+  const factory Group({
+    required String id,
+    required String name,
+    String? description,
+    @JsonKey(name: 'icon_url') String? iconUrl,
+    @JsonKey(name: 'invite_code') required String inviteCode,
+    @JsonKey(name: 'invite_code_expires_at') DateTime? inviteCodeExpiresAt,
+    @JsonKey(name: 'created_by') required String createdBy,
+    @JsonKey(name: 'max_members') @Default(20) int maxMembers,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+    @JsonKey(name: 'updated_at') DateTime? updatedAt,
+  }) = _Group;
+
+  factory Group.fromJson(Map<String, dynamic> json) => _$GroupFromJson(json);
+}
+
+@freezed
+abstract class GroupMember with _$GroupMember {
+  const factory GroupMember({
+    required String id,
+    @JsonKey(name: 'group_id') required String groupId,
+    @JsonKey(name: 'user_id') required String userId,
+    @Default('member') String role,
+    String? nickname,
+    @JsonKey(name: 'joined_at') DateTime? joinedAt,
+  }) = _GroupMember;
+
+  factory GroupMember.fromJson(Map<String, dynamic> json) =>
+      _$GroupMemberFromJson(json);
+}

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification.freezed.dart';
+part 'notification.g.dart';
+
+enum NotificationType {
+  @JsonValue('suggestion_new')
+  suggestionNew,
+  @JsonValue('suggestion_accepted')
+  suggestionAccepted,
+  @JsonValue('group_invite')
+  groupInvite,
+  @JsonValue('schedule_updated')
+  scheduleUpdated,
+  @JsonValue('member_joined')
+  memberJoined,
+}
+
+@freezed
+abstract class AppNotification with _$AppNotification {
+  const factory AppNotification({
+    required String id,
+    @JsonKey(name: 'user_id') required String userId,
+    required NotificationType type,
+    required String title,
+    required String body,
+    @JsonKey(name: 'related_id') String? relatedId,
+    @JsonKey(name: 'is_read') @Default(false) bool isRead,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+  }) = _AppNotification;
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) =>
+      _$AppNotificationFromJson(json);
+}

--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -1,0 +1,47 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'schedule.freezed.dart';
+part 'schedule.g.dart';
+
+enum ScheduleType {
+  @JsonValue('shift')
+  shift,
+  @JsonValue('event')
+  event,
+  @JsonValue('free')
+  free,
+  @JsonValue('blocked')
+  blocked,
+}
+
+enum Visibility {
+  @JsonValue('public')
+  public_,
+  @JsonValue('friends')
+  friends,
+  @JsonValue('private')
+  private_,
+}
+
+@freezed
+abstract class Schedule with _$Schedule {
+  const factory Schedule({
+    required String id,
+    @JsonKey(name: 'user_id') required String userId,
+    required String title,
+    @JsonKey(name: 'schedule_type') required ScheduleType scheduleType,
+    @JsonKey(name: 'start_time') required DateTime startTime,
+    @JsonKey(name: 'end_time') required DateTime endTime,
+    @JsonKey(name: 'is_all_day') @Default(false) bool isAllDay,
+    @JsonKey(name: 'recurrence_rule') String? recurrenceRule,
+    @Default(Visibility.friends) Visibility visibility,
+    String? color,
+    String? memo,
+    @JsonKey(name: 'shift_pattern_id') String? shiftPatternId,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+    @JsonKey(name: 'updated_at') DateTime? updatedAt,
+  }) = _Schedule;
+
+  factory Schedule.fromJson(Map<String, dynamic> json) =>
+      _$ScheduleFromJson(json);
+}

--- a/lib/models/shift_pattern.dart
+++ b/lib/models/shift_pattern.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'shift_pattern.freezed.dart';
+part 'shift_pattern.g.dart';
+
+@freezed
+abstract class ShiftDefinition with _$ShiftDefinition {
+  const factory ShiftDefinition({
+    required String label,
+    String? start,
+    String? end,
+    String? color,
+  }) = _ShiftDefinition;
+
+  factory ShiftDefinition.fromJson(Map<String, dynamic> json) =>
+      _$ShiftDefinitionFromJson(json);
+}
+
+@freezed
+abstract class ShiftPattern with _$ShiftPattern {
+  const factory ShiftPattern({
+    required String id,
+    @JsonKey(name: 'user_id') required String userId,
+    required String name,
+    String? color,
+    required List<ShiftDefinition> shifts,
+    @JsonKey(name: 'rotation_days') int? rotationDays,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+    @JsonKey(name: 'updated_at') DateTime? updatedAt,
+  }) = _ShiftPattern;
+
+  factory ShiftPattern.fromJson(Map<String, dynamic> json) =>
+      _$ShiftPatternFromJson(json);
+}

--- a/lib/models/suggestion.dart
+++ b/lib/models/suggestion.dart
@@ -1,0 +1,66 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'suggestion.freezed.dart';
+part 'suggestion.g.dart';
+
+enum TimeCategory {
+  @JsonValue('morning')
+  morning,
+  @JsonValue('lunch')
+  lunch,
+  @JsonValue('afternoon')
+  afternoon,
+  @JsonValue('evening')
+  evening,
+  @JsonValue('all_day')
+  allDay,
+}
+
+enum SuggestionStatus {
+  @JsonValue('proposed')
+  proposed,
+  @JsonValue('accepted')
+  accepted,
+  @JsonValue('declined')
+  declined,
+  @JsonValue('expired')
+  expired,
+}
+
+@freezed
+abstract class WeatherSummary with _$WeatherSummary {
+  const factory WeatherSummary({
+    required String condition,
+    @JsonKey(name: 'temp_high') double? tempHigh,
+    @JsonKey(name: 'temp_low') double? tempLow,
+    String? icon,
+  }) = _WeatherSummary;
+
+  factory WeatherSummary.fromJson(Map<String, dynamic> json) =>
+      _$WeatherSummaryFromJson(json);
+}
+
+@freezed
+abstract class Suggestion with _$Suggestion {
+  const factory Suggestion({
+    required String id,
+    @JsonKey(name: 'group_id') required String groupId,
+    @JsonKey(name: 'suggested_date') required DateTime suggestedDate,
+    @JsonKey(name: 'start_time') required DateTime startTime,
+    @JsonKey(name: 'end_time') required DateTime endTime,
+    @JsonKey(name: 'duration_hours') required double durationHours,
+    @JsonKey(name: 'time_category') required TimeCategory timeCategory,
+    @JsonKey(name: 'activity_type') required String activityType,
+    @JsonKey(name: 'available_members') required List<String> availableMembers,
+    @JsonKey(name: 'total_members') required int totalMembers,
+    @JsonKey(name: 'availability_ratio') required double availabilityRatio,
+    @JsonKey(name: 'weather_summary') WeatherSummary? weatherSummary,
+    required double score,
+    @Default(SuggestionStatus.proposed) SuggestionStatus status,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+    @JsonKey(name: 'expires_at') required DateTime expiresAt,
+  }) = _Suggestion;
+
+  factory Suggestion.fromJson(Map<String, dynamic> json) =>
+      _$SuggestionFromJson(json);
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+@freezed
+abstract class AppUser with _$AppUser {
+  const factory AppUser({
+    required String id,
+    @JsonKey(name: 'display_name') required String displayName,
+    String? email,
+    @JsonKey(name: 'avatar_url') String? avatarUrl,
+    @JsonKey(name: 'auth_provider') required String authProvider,
+    @JsonKey(name: 'auth_provider_id') required String authProviderId,
+    @JsonKey(name: 'device_token') String? deviceToken,
+    @Default('Asia/Tokyo') String timezone,
+    @JsonKey(name: 'privacy_default') @Default('friends') String privacyDefault,
+    @JsonKey(name: 'created_at') DateTime? createdAt,
+    @JsonKey(name: 'updated_at') DateTime? updatedAt,
+  }) = _AppUser;
+
+  factory AppUser.fromJson(Map<String, dynamic> json) =>
+      _$AppUserFromJson(json);
+}

--- a/test/models/schedule_test.dart
+++ b/test/models/schedule_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:himatch/models/schedule.dart';
+
+void main() {
+  group('Schedule', () {
+    test('fromJson creates schedule correctly', () {
+      final json = {
+        'id': 'schedule-001',
+        'user_id': 'user-001',
+        'title': '早番',
+        'schedule_type': 'shift',
+        'start_time': '2026-03-15T06:00:00.000Z',
+        'end_time': '2026-03-15T15:00:00.000Z',
+        'is_all_day': false,
+        'visibility': 'friends',
+      };
+
+      final schedule = Schedule.fromJson(json);
+
+      expect(schedule.title, '早番');
+      expect(schedule.scheduleType, ScheduleType.shift);
+      expect(schedule.isAllDay, false);
+      expect(schedule.visibility, Visibility.friends);
+      expect(schedule.startTime.year, 2026);
+    });
+
+    test('toJson serializes enum values correctly', () {
+      final schedule = Schedule(
+        id: 'test-id',
+        userId: 'user-001',
+        title: '空き時間',
+        scheduleType: ScheduleType.free,
+        startTime: DateTime(2026, 3, 15, 18, 0),
+        endTime: DateTime(2026, 3, 15, 23, 0),
+      );
+
+      final json = schedule.toJson();
+
+      expect(json['schedule_type'], 'free');
+      expect(json['visibility'], 'friends');
+      expect(json['is_all_day'], false);
+    });
+
+    test('ScheduleType enum has all expected values', () {
+      expect(ScheduleType.values.length, 4);
+      expect(ScheduleType.values, contains(ScheduleType.shift));
+      expect(ScheduleType.values, contains(ScheduleType.event));
+      expect(ScheduleType.values, contains(ScheduleType.free));
+      expect(ScheduleType.values, contains(ScheduleType.blocked));
+    });
+  });
+}

--- a/test/models/suggestion_test.dart
+++ b/test/models/suggestion_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:himatch/models/suggestion.dart';
+
+void main() {
+  group('Suggestion', () {
+    test('fromJson creates suggestion with weather', () {
+      final json = {
+        'id': 'suggestion-001',
+        'group_id': 'group-001',
+        'suggested_date': '2026-03-15T00:00:00.000Z',
+        'start_time': '2026-03-15T18:00:00.000Z',
+        'end_time': '2026-03-15T23:00:00.000Z',
+        'duration_hours': 5.0,
+        'time_category': 'evening',
+        'activity_type': '飲み会',
+        'available_members': ['user-001', 'user-002', 'user-003'],
+        'total_members': 4,
+        'availability_ratio': 0.75,
+        'weather_summary': {
+          'condition': '晴れ',
+          'temp_high': 22.0,
+          'temp_low': 14.0,
+          'icon': '01d',
+        },
+        'score': 85.5,
+        'status': 'proposed',
+        'expires_at': '2026-03-14T00:00:00.000Z',
+      };
+
+      final suggestion = Suggestion.fromJson(json);
+
+      expect(suggestion.activityType, '飲み会');
+      expect(suggestion.timeCategory, TimeCategory.evening);
+      expect(suggestion.availableMembers.length, 3);
+      expect(suggestion.availabilityRatio, 0.75);
+      expect(suggestion.weatherSummary?.condition, '晴れ');
+      expect(suggestion.score, 85.5);
+      expect(suggestion.status, SuggestionStatus.proposed);
+    });
+
+    test('fromJson creates suggestion without weather', () {
+      final json = {
+        'id': 'suggestion-002',
+        'group_id': 'group-001',
+        'suggested_date': '2026-03-20T00:00:00.000Z',
+        'start_time': '2026-03-20T09:00:00.000Z',
+        'end_time': '2026-03-20T21:00:00.000Z',
+        'duration_hours': 12.0,
+        'time_category': 'all_day',
+        'activity_type': '日帰り旅行',
+        'available_members': ['user-001', 'user-002'],
+        'total_members': 2,
+        'availability_ratio': 1.0,
+        'score': 92.0,
+        'status': 'proposed',
+        'expires_at': '2026-03-19T00:00:00.000Z',
+      };
+
+      final suggestion = Suggestion.fromJson(json);
+
+      expect(suggestion.timeCategory, TimeCategory.allDay);
+      expect(suggestion.activityType, '日帰り旅行');
+      expect(suggestion.weatherSummary, isNull);
+      expect(suggestion.availabilityRatio, 1.0);
+    });
+
+    test('TimeCategory has all expected values', () {
+      expect(TimeCategory.values.length, 5);
+      expect(TimeCategory.values, contains(TimeCategory.morning));
+      expect(TimeCategory.values, contains(TimeCategory.lunch));
+      expect(TimeCategory.values, contains(TimeCategory.afternoon));
+      expect(TimeCategory.values, contains(TimeCategory.evening));
+      expect(TimeCategory.values, contains(TimeCategory.allDay));
+    });
+  });
+}

--- a/test/models/user_test.dart
+++ b/test/models/user_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:himatch/models/user.dart';
+
+void main() {
+  group('AppUser', () {
+    test('fromJson creates user correctly', () {
+      final json = {
+        'id': '123e4567-e89b-12d3-a456-426614174000',
+        'display_name': 'テストユーザー',
+        'email': 'test@example.com',
+        'avatar_url': 'https://example.com/avatar.png',
+        'auth_provider': 'apple',
+        'auth_provider_id': 'apple_user_123',
+        'timezone': 'Asia/Tokyo',
+        'privacy_default': 'friends',
+      };
+
+      final user = AppUser.fromJson(json);
+
+      expect(user.id, '123e4567-e89b-12d3-a456-426614174000');
+      expect(user.displayName, 'テストユーザー');
+      expect(user.email, 'test@example.com');
+      expect(user.authProvider, 'apple');
+      expect(user.timezone, 'Asia/Tokyo');
+      expect(user.privacyDefault, 'friends');
+    });
+
+    test('toJson produces correct keys', () {
+      const user = AppUser(
+        id: 'test-id',
+        displayName: 'テスト',
+        authProvider: 'google',
+        authProviderId: 'google_123',
+      );
+
+      final json = user.toJson();
+
+      expect(json['display_name'], 'テスト');
+      expect(json['auth_provider'], 'google');
+      expect(json['auth_provider_id'], 'google_123');
+      expect(json['timezone'], 'Asia/Tokyo');
+      expect(json['privacy_default'], 'friends');
+    });
+
+    test('copyWith works correctly', () {
+      const user = AppUser(
+        id: 'test-id',
+        displayName: 'Before',
+        authProvider: 'apple',
+        authProviderId: 'apple_123',
+      );
+
+      final updated = user.copyWith(displayName: 'After');
+
+      expect(updated.displayName, 'After');
+      expect(updated.id, 'test-id');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

architecture.md の DB スキーマに基づき、Freezed v3 + json_serializable で7つのデータモデルを実装。

Closes #5

## モデル一覧

| モデル | DB テーブル | 主な属性 |
|--------|-----------|---------|
| AppUser | users | displayName, authProvider, timezone, privacyDefault |
| Group | groups | name, inviteCode, maxMembers |
| GroupMember | group_members | role (owner/admin/member), nickname |
| Schedule | schedules | scheduleType (shift/event/free/blocked), startTime, endTime |
| ShiftPattern | shift_patterns | shifts (JSON配列), rotationDays |
| Suggestion | suggestions | timeCategory, activityType, score, weatherSummary |
| AppNotification | notifications | type, isRead |

## 設計判断

- **AppUser** (not User): Dart の built-in User との名前衝突を回避
- **AppNotification** (not Notification): Flutter の Notification クラスとの衝突回避
- **Visibility enum**: `public_` / `private_` とアンダースコア付き（Dart予約語回避）
- **@JsonKey(name:)**: snake_case (DB) ↔ camelCase (Dart) の自動変換
- **analysis_options.yaml**: Freezed v3 の `invalid_annotation_target` 警告を抑制

## Test plan

- [x] flutter analyze: No issues found
- [x] flutter test: 10/10 passed
  - AppUser: fromJson / toJson / copyWith
  - Schedule: fromJson / toJson / enum values
  - Suggestion: fromJson with/without weather / TimeCategory enum

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive model/types and unit tests, with a small analyzer setting change; minimal runtime impact aside from future code depending on these schemas.
> 
> **Overview**
> Implements the app’s core data layer by adding seven Freezed v3 + `json_serializable` models (`AppUser`, `Group`/`GroupMember`, `Schedule`, `ShiftPattern`/`ShiftDefinition`, `Suggestion`/`WeatherSummary`, `AppNotification`) with enums and snake_case↔camelCase JSON mappings.
> 
> Adds unit tests covering model `fromJson`/`toJson` behavior and key enum cases, updates `analysis_options.yaml` to ignore Freezed’s `invalid_annotation_target` analyzer warning, and documents the addition in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1b3c0a7fd7b66208ef4a34601c288ff871bb3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->