### PR TITLE
feat(#10): カレンダーUI & スケジュール入力画面

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DBスキーマ: 7テーブル + GiST インデックス + CHECK制約 + updated_at トリガー
 - RLS ポリシー: 全7テーブルに Row Level Security 設定
 - 開発用 seed データ (3ユーザー、1グループ、12スケジュール)
+- カレンダーUI: table_calendar 統合 (月/2週/週 表示切替、日本語ロケール)
+- スケジュール一覧: 日付タップで当日の予定一覧表示 (種別バッジ + 時刻)
+- スケジュール追加/編集画面: 種別選択 (シフト/予定/空き/不可)、日時ピッカー、終日切替、メモ
+- スケジュール削除: 確認ダイアログ付き
+- ローカル状態管理: LocalSchedulesNotifier (オフラインファースト開発用)
+- 日本語ローカライゼーション (flutter_localizations)

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:himatch/core/theme/app_theme.dart';
 import 'package:himatch/routing/app_router.dart';
 
@@ -16,6 +17,15 @@ class HimatchApp extends ConsumerWidget {
       routerConfig: router,
       debugShowCheckedModeBanner: false,
       locale: const Locale('ja', 'JP'),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('ja', 'JP'),
+        Locale('en', 'US'),
+      ],
     );
   }
 }

--- a/lib/features/schedule/presentation/calendar_tab.dart
+++ b/lib/features/schedule/presentation/calendar_tab.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/core/utils/date_utils.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/features/schedule/presentation/schedule_form_screen.dart';
+import 'package:himatch/features/schedule/presentation/providers/calendar_providers.dart';
+
+class CalendarTab extends ConsumerStatefulWidget {
+  const CalendarTab({super.key});
+
+  @override
+  ConsumerState<CalendarTab> createState() => _CalendarTabState();
+}
+
+class _CalendarTabState extends ConsumerState<CalendarTab> {
+  CalendarFormat _calendarFormat = CalendarFormat.month;
+  DateTime _focusedDay = DateTime.now();
+  DateTime? _selectedDay;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDay = DateTime.now();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final schedules = ref.watch(localSchedulesProvider);
+    final selectedDaySchedules = _getSchedulesForDay(_selectedDay, schedules);
+
+    return Scaffold(
+      body: Column(
+        children: [
+          TableCalendar<Schedule>(
+            firstDay: DateTime.utc(2024, 1, 1),
+            lastDay: DateTime.utc(2030, 12, 31),
+            focusedDay: _focusedDay,
+            calendarFormat: _calendarFormat,
+            locale: 'ja_JP',
+            selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+            eventLoader: (day) => _getSchedulesForDay(day, schedules),
+            startingDayOfWeek: StartingDayOfWeek.monday,
+            calendarStyle: CalendarStyle(
+              todayDecoration: BoxDecoration(
+                color: AppColors.primaryLight.withValues(alpha: 0.5),
+                shape: BoxShape.circle,
+              ),
+              selectedDecoration: const BoxDecoration(
+                color: AppColors.primary,
+                shape: BoxShape.circle,
+              ),
+              markerDecoration: const BoxDecoration(
+                color: AppColors.secondary,
+                shape: BoxShape.circle,
+              ),
+              markerSize: 6,
+              markersMaxCount: 3,
+            ),
+            headerStyle: const HeaderStyle(
+              formatButtonVisible: true,
+              titleCentered: true,
+              formatButtonShowsNext: false,
+            ),
+            onDaySelected: (selectedDay, focusedDay) {
+              setState(() {
+                _selectedDay = selectedDay;
+                _focusedDay = focusedDay;
+              });
+            },
+            onFormatChanged: (format) {
+              setState(() => _calendarFormat = format);
+            },
+            onPageChanged: (focusedDay) {
+              _focusedDay = focusedDay;
+            },
+          ),
+          const SizedBox(height: 8),
+          // Selected day header
+          if (_selectedDay != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Text(
+                    AppDateUtils.formatMonthDayWeek(_selectedDay!),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${selectedDaySchedules.length}件',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: AppColors.textSecondary,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          const SizedBox(height: 8),
+          // Schedule list
+          Expanded(
+            child: selectedDaySchedules.isEmpty
+                ? const Center(
+                    child: Text(
+                      '予定がありません',
+                      style: TextStyle(color: AppColors.textSecondary),
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    itemCount: selectedDaySchedules.length,
+                    itemBuilder: (context, index) {
+                      return _ScheduleCard(
+                        schedule: selectedDaySchedules[index],
+                        onTap: () => _openEditForm(selectedDaySchedules[index]),
+                        onDelete: () => _deleteSchedule(selectedDaySchedules[index]),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openAddForm(),
+        backgroundColor: AppColors.primary,
+        child: const Icon(Icons.add, color: Colors.white),
+      ),
+    );
+  }
+
+  List<Schedule> _getSchedulesForDay(DateTime? day, List<Schedule> schedules) {
+    if (day == null) return [];
+    return schedules.where((s) {
+      final scheduleDate = DateTime(
+        s.startTime.year,
+        s.startTime.month,
+        s.startTime.day,
+      );
+      final targetDate = DateTime(day.year, day.month, day.day);
+      return scheduleDate == targetDate;
+    }).toList();
+  }
+
+  void _openAddForm() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ScheduleFormScreen(
+          initialDate: _selectedDay ?? DateTime.now(),
+        ),
+      ),
+    );
+  }
+
+  void _openEditForm(Schedule schedule) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ScheduleFormScreen(
+          initialDate: schedule.startTime,
+          schedule: schedule,
+        ),
+      ),
+    );
+  }
+
+  void _deleteSchedule(Schedule schedule) {
+    ref.read(localSchedulesProvider.notifier).removeSchedule(schedule.id);
+  }
+}
+
+class _ScheduleCard extends StatelessWidget {
+  final Schedule schedule;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
+
+  const _ScheduleCard({
+    required this.schedule,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              // Color indicator
+              Container(
+                width: 4,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: _getTypeColor(schedule.scheduleType),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(width: 12),
+              // Content
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        _ScheduleTypeBadge(type: schedule.scheduleType),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            schedule.title,
+                            style: const TextStyle(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 15,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      schedule.isAllDay
+                          ? '終日'
+                          : '${AppDateUtils.formatTime(schedule.startTime)} - ${AppDateUtils.formatTime(schedule.endTime)}',
+                      style: const TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // Delete
+              IconButton(
+                icon: const Icon(Icons.delete_outline, size: 20),
+                color: AppColors.textHint,
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('削除確認'),
+                      content: Text('「${schedule.title}」を削除しますか？'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx),
+                          child: const Text('キャンセル'),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(ctx);
+                            onDelete();
+                          },
+                          child: const Text('削除',
+                              style: TextStyle(color: AppColors.error)),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getTypeColor(ScheduleType type) {
+    switch (type) {
+      case ScheduleType.shift:
+        return AppColors.primary;
+      case ScheduleType.event:
+        return AppColors.warning;
+      case ScheduleType.free:
+        return AppColors.success;
+      case ScheduleType.blocked:
+        return AppColors.error;
+    }
+  }
+}
+
+class _ScheduleTypeBadge extends StatelessWidget {
+  final ScheduleType type;
+
+  const _ScheduleTypeBadge({required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (type) {
+      ScheduleType.shift => ('シフト', AppColors.primary),
+      ScheduleType.event => ('予定', AppColors.warning),
+      ScheduleType.free => ('空き', AppColors.success),
+      ScheduleType.blocked => ('不可', AppColors.error),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/schedule/presentation/home_screen.dart
+++ b/lib/features/schedule/presentation/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/features/schedule/presentation/calendar_tab.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -37,7 +38,7 @@ class _HomeScreenState extends State<HomeScreen> {
       body: IndexedStack(
         index: _selectedIndex,
         children: const [
-          _CalendarTab(),
+          CalendarTab(),
           _SuggestionsTab(),
           _GroupsTab(),
           _ProfileTab(),
@@ -75,28 +76,6 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 }
 
-class _CalendarTab extends StatelessWidget {
-  const _CalendarTab();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.calendar_month, size: 64, color: AppColors.primary),
-          SizedBox(height: 16),
-          Text('カレンダー', style: TextStyle(fontSize: 18)),
-          SizedBox(height: 8),
-          Text(
-            'ここにスケジュールが表示されます',
-            style: TextStyle(color: AppColors.textSecondary),
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 class _SuggestionsTab extends StatelessWidget {
   const _SuggestionsTab();

--- a/lib/features/schedule/presentation/providers/calendar_providers.dart
+++ b/lib/features/schedule/presentation/providers/calendar_providers.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:uuid/uuid.dart';
+
+/// Local schedule state for offline-first development.
+/// Will be replaced with Supabase-backed provider when connected.
+final localSchedulesProvider =
+    NotifierProvider<LocalSchedulesNotifier, List<Schedule>>(
+  LocalSchedulesNotifier.new,
+);
+
+class LocalSchedulesNotifier extends Notifier<List<Schedule>> {
+  static const _uuid = Uuid();
+
+  @override
+  List<Schedule> build() => [];
+
+  void addSchedule({
+    required String title,
+    required ScheduleType scheduleType,
+    required DateTime startTime,
+    required DateTime endTime,
+    bool isAllDay = false,
+    String? memo,
+    String? color,
+  }) {
+    final schedule = Schedule(
+      id: _uuid.v4(),
+      userId: 'local-user',
+      title: title,
+      scheduleType: scheduleType,
+      startTime: startTime,
+      endTime: endTime,
+      isAllDay: isAllDay,
+      memo: memo,
+      color: color,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    state = [...state, schedule];
+  }
+
+  void updateSchedule(Schedule updated) {
+    state = [
+      for (final s in state)
+        if (s.id == updated.id) updated else s,
+    ];
+  }
+
+  void removeSchedule(String id) {
+    state = state.where((s) => s.id != id).toList();
+  }
+}

--- a/lib/features/schedule/presentation/schedule_form_screen.dart
+++ b/lib/features/schedule/presentation/schedule_form_screen.dart
@@ -1,0 +1,333 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/core/utils/date_utils.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/features/schedule/presentation/providers/calendar_providers.dart';
+
+class ScheduleFormScreen extends ConsumerStatefulWidget {
+  final DateTime initialDate;
+  final Schedule? schedule;
+
+  const ScheduleFormScreen({
+    super.key,
+    required this.initialDate,
+    this.schedule,
+  });
+
+  @override
+  ConsumerState<ScheduleFormScreen> createState() => _ScheduleFormScreenState();
+}
+
+class _ScheduleFormScreenState extends ConsumerState<ScheduleFormScreen> {
+  late final TextEditingController _titleController;
+  late ScheduleType _selectedType;
+  late DateTime _startTime;
+  late DateTime _endTime;
+  late bool _isAllDay;
+  final _memoController = TextEditingController();
+
+  bool get _isEditing => widget.schedule != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final s = widget.schedule;
+    _titleController = TextEditingController(text: s?.title ?? '');
+    _selectedType = s?.scheduleType ?? ScheduleType.free;
+    _isAllDay = s?.isAllDay ?? false;
+
+    if (s != null) {
+      _startTime = s.startTime;
+      _endTime = s.endTime;
+      _memoController.text = s.memo ?? '';
+    } else {
+      final date = widget.initialDate;
+      _startTime = DateTime(date.year, date.month, date.day, 9, 0);
+      _endTime = DateTime(date.year, date.month, date.day, 17, 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _memoController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEditing ? '予定を編集' : '予定を追加'),
+        actions: [
+          TextButton(
+            onPressed: _save,
+            child: const Text('保存', style: TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Schedule type selector
+            const Text('種別', style: TextStyle(fontWeight: FontWeight.w600)),
+            const SizedBox(height: 8),
+            _TypeSelector(
+              selected: _selectedType,
+              onChanged: (type) {
+                setState(() {
+                  _selectedType = type;
+                  if (_titleController.text.isEmpty) {
+                    _titleController.text = _defaultTitle(type);
+                  }
+                });
+              },
+            ),
+            const SizedBox(height: 20),
+
+            // Title
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'タイトル',
+                hintText: '例: 早番、デート、空き',
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // All day toggle
+            SwitchListTile(
+              title: const Text('終日'),
+              value: _isAllDay,
+              onChanged: (v) => setState(() => _isAllDay = v),
+              contentPadding: EdgeInsets.zero,
+              activeThumbColor: AppColors.primary,
+            ),
+
+            // Date & time pickers
+            const Text('日時', style: TextStyle(fontWeight: FontWeight.w600)),
+            const SizedBox(height: 8),
+            _DateTimePicker(
+              label: '開始',
+              dateTime: _startTime,
+              showTime: !_isAllDay,
+              onChanged: (dt) {
+                setState(() {
+                  _startTime = dt;
+                  if (_endTime.isBefore(_startTime)) {
+                    _endTime = _startTime.add(const Duration(hours: 1));
+                  }
+                });
+              },
+            ),
+            const SizedBox(height: 8),
+            _DateTimePicker(
+              label: '終了',
+              dateTime: _endTime,
+              showTime: !_isAllDay,
+              onChanged: (dt) => setState(() => _endTime = dt),
+            ),
+            const SizedBox(height: 20),
+
+            // Memo
+            TextField(
+              controller: _memoController,
+              decoration: const InputDecoration(
+                labelText: 'メモ（任意）',
+                hintText: '備考があれば入力',
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _defaultTitle(ScheduleType type) {
+    return switch (type) {
+      ScheduleType.shift => 'シフト',
+      ScheduleType.event => '予定',
+      ScheduleType.free => '空き',
+      ScheduleType.blocked => '予定あり',
+    };
+  }
+
+  void _save() {
+    final title = _titleController.text.trim();
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('タイトルを入力してください')),
+      );
+      return;
+    }
+
+    final startTime = _isAllDay
+        ? DateTime(_startTime.year, _startTime.month, _startTime.day)
+        : _startTime;
+    final endTime = _isAllDay
+        ? DateTime(_startTime.year, _startTime.month, _startTime.day, 23, 59)
+        : _endTime;
+
+    if (!endTime.isAfter(startTime)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('終了時刻は開始時刻より後にしてください')),
+      );
+      return;
+    }
+
+    final notifier = ref.read(localSchedulesProvider.notifier);
+
+    if (_isEditing) {
+      notifier.updateSchedule(
+        widget.schedule!.copyWith(
+          title: title,
+          scheduleType: _selectedType,
+          startTime: startTime,
+          endTime: endTime,
+          isAllDay: _isAllDay,
+          memo: _memoController.text.trim().isEmpty
+              ? null
+              : _memoController.text.trim(),
+        ),
+      );
+    } else {
+      notifier.addSchedule(
+        title: title,
+        scheduleType: _selectedType,
+        startTime: startTime,
+        endTime: endTime,
+        isAllDay: _isAllDay,
+        memo: _memoController.text.trim().isEmpty
+            ? null
+            : _memoController.text.trim(),
+      );
+    }
+
+    Navigator.of(context).pop();
+  }
+}
+
+class _TypeSelector extends StatelessWidget {
+  final ScheduleType selected;
+  final ValueChanged<ScheduleType> onChanged;
+
+  const _TypeSelector({
+    required this.selected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: ScheduleType.values.map((type) {
+        final isSelected = type == selected;
+        final (label, color) = switch (type) {
+          ScheduleType.shift => ('シフト', AppColors.primary),
+          ScheduleType.event => ('予定', AppColors.warning),
+          ScheduleType.free => ('空き', AppColors.success),
+          ScheduleType.blocked => ('不可', AppColors.error),
+        };
+
+        return Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: ChoiceChip(
+              label: Text(label),
+              selected: isSelected,
+              onSelected: (_) => onChanged(type),
+              selectedColor: color.withValues(alpha: 0.2),
+              labelStyle: TextStyle(
+                color: isSelected ? color : AppColors.textSecondary,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                fontSize: 13,
+              ),
+              side: BorderSide(
+                color: isSelected ? color : AppColors.textHint,
+              ),
+              showCheckmark: false,
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _DateTimePicker extends StatelessWidget {
+  final String label;
+  final DateTime dateTime;
+  final bool showTime;
+  final ValueChanged<DateTime> onChanged;
+
+  const _DateTimePicker({
+    required this.label,
+    required this.dateTime,
+    required this.showTime,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 40,
+          child: Text(label, style: const TextStyle(color: AppColors.textSecondary)),
+        ),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: () async {
+              final date = await showDatePicker(
+                context: context,
+                initialDate: dateTime,
+                firstDate: DateTime(2024),
+                lastDate: DateTime(2030),
+                locale: const Locale('ja'),
+              );
+              if (date != null) {
+                onChanged(DateTime(
+                  date.year,
+                  date.month,
+                  date.day,
+                  dateTime.hour,
+                  dateTime.minute,
+                ));
+              }
+            },
+            icon: const Icon(Icons.calendar_today, size: 16),
+            label: Text(AppDateUtils.formatDate(dateTime)),
+          ),
+        ),
+        if (showTime) ...[
+          const SizedBox(width: 8),
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: () async {
+                final time = await showTimePicker(
+                  context: context,
+                  initialTime: TimeOfDay.fromDateTime(dateTime),
+                );
+                if (time != null) {
+                  onChanged(DateTime(
+                    dateTime.year,
+                    dateTime.month,
+                    dateTime.day,
+                    time.hour,
+                    time.minute,
+                  ));
+                }
+              },
+              icon: const Icon(Icons.access_time, size: 16),
+              label: Text(AppDateUtils.formatTime(dateTime)),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   cupertino_icons: ^1.0.8
 


### PR DESCRIPTION
## Summary

table_calendar を使ったカレンダー表示、スケジュール一覧、追加/編集/削除画面を実装。

Closes #10

## 画面一覧

### CalendarTab
- table_calendar: 月/2週/週 切替、日本語ロケール、マーカー表示
- 日付タップ → 当日のスケジュール一覧を表示
- FAB → スケジュール追加画面へ

### ScheduleCard
- 種別バッジ (シフト=紫, 予定=黄, 空き=緑, 不可=赤)
- カラーインジケーター (左端4px)
- 終日 or 開始-終了時刻 表示
- タップで編集、ゴミ箱で削除 (確認ダイアログ)

### ScheduleFormScreen
- 種別: ChoiceChip (4種)、選択で自動タイトル入力
- 終日: SwitchListTile (ON → 時刻ピッカー非表示)
- 日時: DatePicker + TimePicker (日本語)
- メモ: 任意テキスト
- バリデーション: タイトル空チェック、終了>開始チェック

## 設計判断

- **LocalSchedulesNotifier**: Supabase 接続前のオフラインファースト開発用。将来 ScheduleService に置換
- **flutter_localizations**: DatePicker/TimePicker の日本語表示に必須
- **マーカー最大3個**: カレンダーのマーカー過多による見にくさ防止
- **種別バッジ**: UI/UX設計書のカラーコーディング準拠

## Test plan
- [x] flutter analyze: No issues
- [x] flutter test: 10/10 passed