### PR TITLE
feat(#15): 候補日提案エンジン & 提案タブUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - グループ退出機能 (確認ダイアログ付き)
 - ローカルグループ状態管理 (LocalGroupsNotifier / LocalGroupMembersNotifier)
 - グループ機能テスト (13テスト)
+- 候補日提案エンジン (SuggestionEngine): 空き時間重複検出 + 文脈付きアクティビティ提案
+  - 30分解像度でメンバー空き時間スキャン (8:00-22:00)
+  - TimeCategory 自動分類 (朝/昼/午後/夜/終日)
+  - ActivityType 推定 (ランチ/飲み会/カフェ/日帰り旅行 etc.)
+  - スコアリング: 可用率 × 時間帯重み × 曜日重み
+- 提案タブUI (SuggestionsTab): 候補日カード一覧 + スコア表示 + 参加可能率バー
+- 提案カード操作: 承認 (Accept) / 見送り (Decline) ステータス変更
+- ローカル提案状態管理 (LocalSuggestionsNotifier)
+- 提案エンジンテスト (12テスト)

--- a/lib/features/schedule/presentation/home_screen.dart
+++ b/lib/features/schedule/presentation/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:himatch/core/theme/app_theme.dart';
 import 'package:himatch/features/schedule/presentation/calendar_tab.dart';
 import 'package:himatch/features/group/presentation/groups_tab.dart';
+import 'package:himatch/features/suggestion/presentation/suggestions_tab.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -40,7 +41,7 @@ class _HomeScreenState extends State<HomeScreen> {
         index: _selectedIndex,
         children: const [
           CalendarTab(),
-          _SuggestionsTab(),
+          SuggestionsTab(),
           GroupsTab(),
           _ProfileTab(),
         ],
@@ -77,29 +78,6 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 }
 
-
-class _SuggestionsTab extends StatelessWidget {
-  const _SuggestionsTab();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.lightbulb, size: 64, color: AppColors.primary),
-          SizedBox(height: 16),
-          Text('候補日提案', style: TextStyle(fontSize: 18)),
-          SizedBox(height: 8),
-          Text(
-            'グループに参加すると候補日が表示されます',
-            style: TextStyle(color: AppColors.textSecondary),
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 
 class _ProfileTab extends StatelessWidget {

--- a/lib/features/suggestion/domain/suggestion_engine.dart
+++ b/lib/features/suggestion/domain/suggestion_engine.dart
@@ -1,0 +1,481 @@
+import 'package:himatch/core/constants/app_constants.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:uuid/uuid.dart';
+
+/// Pure Dart suggestion engine.
+/// Analyzes group members' schedules to find overlapping free time slots
+/// and generates context-aware date suggestions.
+class SuggestionEngine {
+  static const _uuid = Uuid();
+
+  /// Generate suggestions for a group based on members' schedules.
+  ///
+  /// [memberSchedules] maps userId -> list of schedules.
+  /// [searchRangeDays] how many days ahead to search.
+  /// [groupId] the group to generate suggestions for.
+  List<Suggestion> generateSuggestions({
+    required Map<String, List<Schedule>> memberSchedules,
+    required String groupId,
+    int searchRangeDays = AppConstants.defaultSearchRangeDays,
+  }) {
+    if (memberSchedules.length < AppConstants.minGroupMembers) {
+      return [];
+    }
+
+    final totalMembers = memberSchedules.length;
+    final memberIds = memberSchedules.keys.toList();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final suggestions = <Suggestion>[];
+
+    // Scan each day in the search range
+    for (int dayOffset = 1; dayOffset <= searchRangeDays; dayOffset++) {
+      final date = today.add(Duration(days: dayOffset));
+      final isWeekend = date.weekday == DateTime.saturday ||
+          date.weekday == DateTime.sunday;
+
+      // Find free slots for each member on this day
+      final memberFreeSlots = <String, List<_TimeSlot>>{};
+      for (final userId in memberIds) {
+        final schedules = memberSchedules[userId] ?? [];
+        final freeSlots = _findFreeSlotsForDay(date, schedules);
+        memberFreeSlots[userId] = freeSlots;
+      }
+
+      // Find overlapping free time slots across members
+      final overlaps = _findOverlappingSlots(memberFreeSlots, memberIds);
+
+      for (final overlap in overlaps) {
+        if (overlap.availableMembers.length < AppConstants.minGroupMembers) {
+          continue;
+        }
+
+        final durationHours = overlap.slot.durationHours;
+        if (durationHours < 1.0) continue; // Skip slots less than 1 hour
+
+        final timeCategory = _classifyTimeCategory(overlap.slot);
+        final activityType = _suggestActivity(
+          timeCategory: timeCategory,
+          durationHours: durationHours,
+          isWeekend: isWeekend,
+        );
+        final availabilityRatio =
+            overlap.availableMembers.length / totalMembers;
+
+        final score = _calculateScore(
+          availabilityRatio: availabilityRatio,
+          durationHours: durationHours,
+          timeCategory: timeCategory,
+          isWeekend: isWeekend,
+        );
+
+        suggestions.add(Suggestion(
+          id: _uuid.v4(),
+          groupId: groupId,
+          suggestedDate: date,
+          startTime: DateTime(
+            date.year,
+            date.month,
+            date.day,
+            overlap.slot.startHour,
+            overlap.slot.startMinute,
+          ),
+          endTime: DateTime(
+            date.year,
+            date.month,
+            date.day,
+            overlap.slot.endHour,
+            overlap.slot.endMinute,
+          ),
+          durationHours: durationHours,
+          timeCategory: timeCategory,
+          activityType: activityType,
+          availableMembers: overlap.availableMembers,
+          totalMembers: totalMembers,
+          availabilityRatio: availabilityRatio,
+          score: score,
+          status: SuggestionStatus.proposed,
+          createdAt: DateTime.now(),
+          expiresAt: date.add(const Duration(days: 1)),
+        ));
+      }
+    }
+
+    // Sort by score descending, then by date ascending
+    suggestions.sort((a, b) {
+      final scoreCompare = b.score.compareTo(a.score);
+      if (scoreCompare != 0) return scoreCompare;
+      return a.suggestedDate.compareTo(b.suggestedDate);
+    });
+
+    return suggestions;
+  }
+
+  /// Find free time slots for a specific day based on user's schedules.
+  List<_TimeSlot> _findFreeSlotsForDay(
+    DateTime date,
+    List<Schedule> schedules,
+  ) {
+    final dayStart = DateTime(date.year, date.month, date.day, 8, 0);
+    final dayEnd = DateTime(date.year, date.month, date.day, 22, 0);
+
+    // Collect all blocked intervals for this day
+    final blocked = <_TimeSlot>[];
+
+    for (final schedule in schedules) {
+      if (!_isOnDay(schedule, date)) continue;
+
+      // Free schedules don't block time
+      if (schedule.scheduleType == ScheduleType.free) continue;
+
+      if (schedule.isAllDay) {
+        // All-day non-free event blocks the whole day
+        return [];
+      }
+
+      blocked.add(_TimeSlot(
+        startHour: schedule.startTime.hour,
+        startMinute: schedule.startTime.minute,
+        endHour: schedule.endTime.hour,
+        endMinute: schedule.endTime.minute,
+      ));
+    }
+
+    // Also check for explicit free slots
+    final freeSlots = <_TimeSlot>[];
+    bool hasExplicitFree = false;
+
+    for (final schedule in schedules) {
+      if (!_isOnDay(schedule, date)) continue;
+      if (schedule.scheduleType != ScheduleType.free) continue;
+      hasExplicitFree = true;
+
+      if (schedule.isAllDay) {
+        freeSlots.add(_TimeSlot(
+          startHour: dayStart.hour,
+          startMinute: dayStart.minute,
+          endHour: dayEnd.hour,
+          endMinute: dayEnd.minute,
+        ));
+      } else {
+        freeSlots.add(_TimeSlot(
+          startHour: schedule.startTime.hour,
+          startMinute: schedule.startTime.minute,
+          endHour: schedule.endTime.hour,
+          endMinute: schedule.endTime.minute,
+        ));
+      }
+    }
+
+    // If user has explicit free slots, use those (minus blocked)
+    if (hasExplicitFree) {
+      return _subtractBlocked(freeSlots, blocked);
+    }
+
+    // If no explicit free and no blocked, assume available 8-22
+    if (blocked.isEmpty) {
+      return [
+        _TimeSlot(
+          startHour: dayStart.hour,
+          startMinute: dayStart.minute,
+          endHour: dayEnd.hour,
+          endMinute: dayEnd.minute,
+        ),
+      ];
+    }
+
+    // Otherwise, find gaps between blocked intervals
+    return _findGaps(dayStart, dayEnd, blocked);
+  }
+
+  bool _isOnDay(Schedule schedule, DateTime date) {
+    final scheduleDate = DateTime(
+      schedule.startTime.year,
+      schedule.startTime.month,
+      schedule.startTime.day,
+    );
+    final targetDate = DateTime(date.year, date.month, date.day);
+    return scheduleDate == targetDate;
+  }
+
+  /// Subtract blocked time from free slots.
+  List<_TimeSlot> _subtractBlocked(
+    List<_TimeSlot> freeSlots,
+    List<_TimeSlot> blocked,
+  ) {
+    if (blocked.isEmpty) return freeSlots;
+
+    var result = List<_TimeSlot>.from(freeSlots);
+    for (final b in blocked) {
+      final newResult = <_TimeSlot>[];
+      for (final f in result) {
+        newResult.addAll(_subtractInterval(f, b));
+      }
+      result = newResult;
+    }
+    return result;
+  }
+
+  /// Remove interval [b] from interval [f], returning remaining parts.
+  List<_TimeSlot> _subtractInterval(_TimeSlot f, _TimeSlot b) {
+    final fStart = f.startMinutes;
+    final fEnd = f.endMinutes;
+    final bStart = b.startMinutes;
+    final bEnd = b.endMinutes;
+
+    // No overlap
+    if (bEnd <= fStart || bStart >= fEnd) return [f];
+
+    final result = <_TimeSlot>[];
+
+    // Left remainder
+    if (bStart > fStart) {
+      result.add(_TimeSlot.fromMinutes(fStart, bStart));
+    }
+
+    // Right remainder
+    if (bEnd < fEnd) {
+      result.add(_TimeSlot.fromMinutes(bEnd, fEnd));
+    }
+
+    return result;
+  }
+
+  /// Find gaps between blocked intervals within [dayStart, dayEnd].
+  List<_TimeSlot> _findGaps(
+    DateTime dayStart,
+    DateTime dayEnd,
+    List<_TimeSlot> blocked,
+  ) {
+    final sorted = List<_TimeSlot>.from(blocked)
+      ..sort((a, b) => a.startMinutes.compareTo(b.startMinutes));
+
+    final gaps = <_TimeSlot>[];
+    int current = dayStart.hour * 60 + dayStart.minute;
+    final end = dayEnd.hour * 60 + dayEnd.minute;
+
+    for (final slot in sorted) {
+      if (slot.startMinutes > current) {
+        gaps.add(_TimeSlot.fromMinutes(current, slot.startMinutes));
+      }
+      if (slot.endMinutes > current) {
+        current = slot.endMinutes;
+      }
+    }
+
+    if (current < end) {
+      gaps.add(_TimeSlot.fromMinutes(current, end));
+    }
+
+    return gaps;
+  }
+
+  /// Find overlapping free slots across all members.
+  List<_OverlapResult> _findOverlappingSlots(
+    Map<String, List<_TimeSlot>> memberFreeSlots,
+    List<String> memberIds,
+  ) {
+    if (memberIds.isEmpty) return [];
+
+    // Merge all slots into a timeline to find potential windows
+    final candidateSlots = <_TimeSlot>{};
+    for (final slots in memberFreeSlots.values) {
+      candidateSlots.addAll(slots);
+    }
+
+    // For each unique time window, find which members are available
+    final results = <_OverlapResult>[];
+
+    // Use 30-minute resolution for scanning
+    for (int startMin = 8 * 60; startMin < 22 * 60; startMin += 30) {
+      // Try different durations: 1h, 2h, 3h, 4h, 8h
+      for (final durationMin in [60, 120, 180, 240, 480]) {
+        final endMin = startMin + durationMin;
+        if (endMin > 22 * 60) break;
+
+        final window = _TimeSlot.fromMinutes(startMin, endMin);
+        final availableMembers = <String>[];
+
+        for (final userId in memberIds) {
+          final slots = memberFreeSlots[userId] ?? [];
+          if (_isFullyCovered(window, slots)) {
+            availableMembers.add(userId);
+          }
+        }
+
+        if (availableMembers.length >= AppConstants.minGroupMembers) {
+          // Check if this is a superset of existing results (dedup)
+          final isDuplicate = results.any((r) =>
+              r.slot.startMinutes == window.startMinutes &&
+              r.slot.endMinutes == window.endMinutes);
+          if (!isDuplicate) {
+            results.add(_OverlapResult(
+              slot: window,
+              availableMembers: availableMembers,
+            ));
+          }
+        }
+      }
+    }
+
+    // Remove dominated results (subset of a larger slot with same members)
+    return _deduplicateOverlaps(results);
+  }
+
+  /// Check if a time window is fully covered by the given free slots.
+  bool _isFullyCovered(_TimeSlot window, List<_TimeSlot> freeSlots) {
+    for (final slot in freeSlots) {
+      if (slot.startMinutes <= window.startMinutes &&
+          slot.endMinutes >= window.endMinutes) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Remove dominated overlaps: keep only the best (longest or most members)
+  /// per approximate time window.
+  List<_OverlapResult> _deduplicateOverlaps(List<_OverlapResult> results) {
+    if (results.isEmpty) return results;
+
+    // Group by approximate start time (within 1 hour) and keep best per group
+    final grouped = <int, List<_OverlapResult>>{};
+    for (final r in results) {
+      final key = r.slot.startMinutes ~/ 60;
+      grouped.putIfAbsent(key, () => []).add(r);
+    }
+
+    final deduped = <_OverlapResult>[];
+    for (final group in grouped.values) {
+      // Sort by member count desc, then duration desc
+      group.sort((a, b) {
+        final memberCompare = b.availableMembers.length
+            .compareTo(a.availableMembers.length);
+        if (memberCompare != 0) return memberCompare;
+        return b.slot.durationMinutes.compareTo(a.slot.durationMinutes);
+      });
+      deduped.add(group.first);
+    }
+
+    return deduped;
+  }
+
+  /// Classify time slot into a TimeCategory.
+  TimeCategory _classifyTimeCategory(_TimeSlot slot) {
+    final durationHours = slot.durationHours;
+
+    if (durationHours >= AppConstants.allDayThreshold) {
+      return TimeCategory.allDay;
+    }
+
+    final midpointMinutes =
+        (slot.startMinutes + slot.endMinutes) ~/ 2;
+    final midpointHour = midpointMinutes / 60;
+
+    if (midpointHour < AppConstants.lunchStartHour) {
+      return TimeCategory.morning;
+    } else if (midpointHour < AppConstants.lunchEndHour) {
+      return TimeCategory.lunch;
+    } else if (midpointHour < AppConstants.eveningStartHour) {
+      return TimeCategory.afternoon;
+    } else {
+      return TimeCategory.evening;
+    }
+  }
+
+  /// Suggest an activity type based on context.
+  String _suggestActivity({
+    required TimeCategory timeCategory,
+    required double durationHours,
+    required bool isWeekend,
+  }) {
+    return switch (timeCategory) {
+      TimeCategory.morning => isWeekend ? 'お出かけ' : 'カフェ',
+      TimeCategory.lunch => 'ランチ',
+      TimeCategory.afternoon =>
+        durationHours >= 4 ? (isWeekend ? '日帰り旅行' : '遊び') : 'カフェ',
+      TimeCategory.evening => isWeekend ? 'ディナー' : '飲み会',
+      TimeCategory.allDay => isWeekend ? '日帰り旅行' : '遊び',
+    };
+  }
+
+  /// Calculate suggestion score (0.0 - 1.0).
+  double _calculateScore({
+    required double availabilityRatio,
+    required double durationHours,
+    required TimeCategory timeCategory,
+    required bool isWeekend,
+  }) {
+    // Base: availability ratio (most important)
+    double score = availabilityRatio * 0.5;
+
+    // Duration weight (longer is generally better, up to a point)
+    final durationScore = (durationHours / 8.0).clamp(0.0, 1.0);
+    score += durationScore * 0.2;
+
+    // Weekend bonus
+    if (isWeekend) score += 0.1;
+
+    // Time category bonus (evening/lunch are popular for social)
+    final timeCategoryBonus = switch (timeCategory) {
+      TimeCategory.evening => 0.15,
+      TimeCategory.lunch => 0.12,
+      TimeCategory.afternoon => 0.08,
+      TimeCategory.allDay => 0.1,
+      TimeCategory.morning => 0.05,
+    };
+    score += timeCategoryBonus;
+
+    return score.clamp(0.0, 1.0);
+  }
+}
+
+/// Internal time slot representation using hours and minutes.
+class _TimeSlot {
+  final int startHour;
+  final int startMinute;
+  final int endHour;
+  final int endMinute;
+
+  const _TimeSlot({
+    required this.startHour,
+    required this.startMinute,
+    required this.endHour,
+    required this.endMinute,
+  });
+
+  factory _TimeSlot.fromMinutes(int startMin, int endMin) {
+    return _TimeSlot(
+      startHour: startMin ~/ 60,
+      startMinute: startMin % 60,
+      endHour: endMin ~/ 60,
+      endMinute: endMin % 60,
+    );
+  }
+
+  int get startMinutes => startHour * 60 + startMinute;
+  int get endMinutes => endHour * 60 + endMinute;
+  int get durationMinutes => endMinutes - startMinutes;
+  double get durationHours => durationMinutes / 60.0;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _TimeSlot &&
+          startMinutes == other.startMinutes &&
+          endMinutes == other.endMinutes;
+
+  @override
+  int get hashCode => startMinutes.hashCode ^ endMinutes.hashCode;
+}
+
+class _OverlapResult {
+  final _TimeSlot slot;
+  final List<String> availableMembers;
+
+  const _OverlapResult({
+    required this.slot,
+    required this.availableMembers,
+  });
+}

--- a/lib/features/suggestion/presentation/providers/suggestion_providers.dart
+++ b/lib/features/suggestion/presentation/providers/suggestion_providers.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:himatch/features/suggestion/domain/suggestion_engine.dart';
+import 'package:himatch/features/schedule/presentation/providers/calendar_providers.dart';
+import 'package:himatch/features/group/presentation/providers/group_providers.dart';
+
+final suggestionEngineProvider = Provider<SuggestionEngine>((ref) {
+  return SuggestionEngine();
+});
+
+/// Local suggestions state for offline-first development.
+final localSuggestionsProvider =
+    NotifierProvider<LocalSuggestionsNotifier, List<Suggestion>>(
+  LocalSuggestionsNotifier.new,
+);
+
+class LocalSuggestionsNotifier extends Notifier<List<Suggestion>> {
+  @override
+  List<Suggestion> build() => [];
+
+  /// Run the suggestion engine against local data.
+  void refreshSuggestions() {
+    final engine = ref.read(suggestionEngineProvider);
+    final groups = ref.read(localGroupsProvider);
+    final schedules = ref.read(localSchedulesProvider);
+
+    if (groups.isEmpty) {
+      state = [];
+      return;
+    }
+
+    final allSuggestions = <Suggestion>[];
+
+    for (final group in groups) {
+      final members =
+          ref.read(localGroupMembersProvider)[group.id] ?? [];
+      if (members.length < 2) continue;
+
+      // Build memberSchedules map
+      // In offline mode, all local schedules belong to 'local-user'
+      // Simulate other members having no schedules (fully free)
+      final memberSchedules = <String, List<Schedule>>{};
+      for (final member in members) {
+        if (member.userId == 'local-user') {
+          memberSchedules[member.userId] = schedules;
+        } else {
+          memberSchedules[member.userId] = [];
+        }
+      }
+
+      final suggestions = engine.generateSuggestions(
+        memberSchedules: memberSchedules,
+        groupId: group.id,
+      );
+      allSuggestions.addAll(suggestions);
+    }
+
+    // Sort all suggestions by score
+    allSuggestions.sort((a, b) => b.score.compareTo(a.score));
+    state = allSuggestions;
+  }
+
+  void updateStatus(String id, SuggestionStatus status) {
+    state = [
+      for (final s in state)
+        if (s.id == id) s.copyWith(status: status) else s,
+    ];
+  }
+
+  void clear() {
+    state = [];
+  }
+}

--- a/lib/features/suggestion/presentation/suggestions_tab.dart
+++ b/lib/features/suggestion/presentation/suggestions_tab.dart
@@ -1,0 +1,533 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/core/utils/date_utils.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:himatch/features/suggestion/presentation/providers/suggestion_providers.dart';
+import 'package:himatch/features/group/presentation/providers/group_providers.dart';
+
+class SuggestionsTab extends ConsumerWidget {
+  const SuggestionsTab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final suggestions = ref.watch(localSuggestionsProvider);
+    final groups = ref.watch(localGroupsProvider);
+
+    return Scaffold(
+      body: groups.isEmpty
+          ? _NoGroupState()
+          : suggestions.isEmpty
+              ? _EmptySuggestionState(ref: ref)
+              : _SuggestionList(suggestions: suggestions),
+      floatingActionButton: groups.isNotEmpty
+          ? FloatingActionButton.extended(
+              onPressed: () {
+                ref
+                    .read(localSuggestionsProvider.notifier)
+                    .refreshSuggestions();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('候補日を更新しました')),
+                );
+              },
+              backgroundColor: AppColors.primary,
+              icon: const Icon(Icons.refresh, color: Colors.white),
+              label: const Text('更新',
+                  style: TextStyle(color: Colors.white)),
+            )
+          : null,
+    );
+  }
+}
+
+class _NoGroupState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.group_add_outlined,
+              size: 80,
+              color: AppColors.primary.withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'グループに参加しましょう',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'グループタブでグループを作成または\n招待コードで参加すると候補日が表示されます',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptySuggestionState extends StatelessWidget {
+  final WidgetRef ref;
+
+  const _EmptySuggestionState({required this.ref});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.lightbulb_outline,
+              size: 80,
+              color: AppColors.warning.withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              '候補日がありません',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '右下の「更新」ボタンをタップして\n候補日を検索しましょう',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              onPressed: () {
+                ref
+                    .read(localSuggestionsProvider.notifier)
+                    .refreshSuggestions();
+              },
+              icon: const Icon(Icons.search),
+              label: const Text('候補日を検索'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SuggestionList extends ConsumerWidget {
+  final List<Suggestion> suggestions;
+
+  const _SuggestionList({required this.suggestions});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final proposed =
+        suggestions.where((s) => s.status == SuggestionStatus.proposed).toList();
+    final accepted =
+        suggestions.where((s) => s.status == SuggestionStatus.accepted).toList();
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Stats header
+        Row(
+          children: [
+            Text(
+              '${suggestions.length}件の候補',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const Spacer(),
+            if (accepted.isNotEmpty)
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: AppColors.success.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '${accepted.length}件承認済み',
+                  style: const TextStyle(
+                    color: AppColors.success,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        // Proposed suggestions
+        ...proposed.map((s) => _SuggestionCard(suggestion: s)),
+        // Accepted suggestions
+        if (accepted.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          const Text(
+            '承認済み',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              color: AppColors.success,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...accepted.map((s) => _SuggestionCard(suggestion: s)),
+        ],
+      ],
+    );
+  }
+}
+
+class _SuggestionCard extends ConsumerWidget {
+  final Suggestion suggestion;
+
+  const _SuggestionCard({required this.suggestion});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isAccepted = suggestion.status == SuggestionStatus.accepted;
+    final groups = ref.watch(localGroupsProvider);
+    final groupName = groups
+        .where((g) => g.id == suggestion.groupId)
+        .map((g) => g.name)
+        .firstOrNull;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: isAccepted
+            ? const BorderSide(color: AppColors.success, width: 2)
+            : BorderSide.none,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Top row: date & score
+            Row(
+              children: [
+                // Date badge
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: AppColors.primary.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    AppDateUtils.formatMonthDayWeek(suggestion.suggestedDate),
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.primary,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                // Score indicator
+                _ScoreBadge(score: suggestion.score),
+              ],
+            ),
+            const SizedBox(height: 12),
+
+            // Activity & time
+            Row(
+              children: [
+                Icon(
+                  _getActivityIcon(suggestion.activityType),
+                  size: 20,
+                  color: AppColors.textSecondary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  suggestion.activityType,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                _TimeCategoryBadge(category: suggestion.timeCategory),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            // Time range
+            Row(
+              children: [
+                const Icon(Icons.access_time, size: 16, color: AppColors.textHint),
+                const SizedBox(width: 4),
+                Text(
+                  '${AppDateUtils.formatTime(suggestion.startTime)} - ${AppDateUtils.formatTime(suggestion.endTime)}'
+                  ' (${suggestion.durationHours.toStringAsFixed(1)}h)',
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+
+            // Members
+            Row(
+              children: [
+                const Icon(Icons.people_outline,
+                    size: 16, color: AppColors.textHint),
+                const SizedBox(width: 4),
+                Text(
+                  '${suggestion.availableMembers.length}/${suggestion.totalMembers}人が参加可能',
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                ),
+                if (groupName != null) ...[
+                  const SizedBox(width: 8),
+                  Text(
+                    groupName,
+                    style: const TextStyle(
+                      color: AppColors.textHint,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            const SizedBox(height: 12),
+
+            // Availability bar
+            _AvailabilityBar(ratio: suggestion.availabilityRatio),
+            const SizedBox(height: 12),
+
+            // Action buttons
+            if (!isAccepted)
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () {
+                        ref
+                            .read(localSuggestionsProvider.notifier)
+                            .updateStatus(
+                                suggestion.id, SuggestionStatus.declined);
+                      },
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.textSecondary,
+                      ),
+                      child: const Text('見送り'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 2,
+                    child: ElevatedButton.icon(
+                      onPressed: () {
+                        ref
+                            .read(localSuggestionsProvider.notifier)
+                            .updateStatus(
+                                suggestion.id, SuggestionStatus.accepted);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              '${AppDateUtils.formatMonthDayWeek(suggestion.suggestedDate)}の${suggestion.activityType}を承認しました',
+                            ),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.check, size: 18),
+                      label: const Text('この日にする！'),
+                    ),
+                  ),
+                ],
+              ),
+            if (isAccepted)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                decoration: BoxDecoration(
+                  color: AppColors.success.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.check_circle, color: AppColors.success, size: 18),
+                    SizedBox(width: 6),
+                    Text(
+                      '承認済み',
+                      style: TextStyle(
+                        color: AppColors.success,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _getActivityIcon(String activityType) {
+    return switch (activityType) {
+      'ランチ' => Icons.restaurant,
+      '飲み会' || 'ディナー' => Icons.local_bar,
+      'カフェ' => Icons.coffee,
+      '日帰り旅行' => Icons.directions_car,
+      'お出かけ' || '遊び' => Icons.celebration,
+      _ => Icons.event,
+    };
+  }
+}
+
+class _ScoreBadge extends StatelessWidget {
+  final double score;
+
+  const _ScoreBadge({required this.score});
+
+  @override
+  Widget build(BuildContext context) {
+    final percentage = (score * 100).round();
+    final color = score >= 0.7
+        ? AppColors.success
+        : score >= 0.4
+            ? AppColors.warning
+            : AppColors.textSecondary;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.star, size: 14, color: color),
+          const SizedBox(width: 2),
+          Text(
+            '$percentage%',
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimeCategoryBadge extends StatelessWidget {
+  final TimeCategory category;
+
+  const _TimeCategoryBadge({required this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, icon) = switch (category) {
+      TimeCategory.morning => ('朝', Icons.wb_sunny),
+      TimeCategory.lunch => ('昼', Icons.restaurant),
+      TimeCategory.afternoon => ('午後', Icons.wb_cloudy),
+      TimeCategory.evening => ('夜', Icons.nightlight_round),
+      TimeCategory.allDay => ('終日', Icons.calendar_today),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceVariant,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 12, color: AppColors.textSecondary),
+          const SizedBox(width: 2),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 11,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AvailabilityBar extends StatelessWidget {
+  final double ratio;
+
+  const _AvailabilityBar({required this.ratio});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = ratio >= 0.8
+        ? AppColors.success
+        : ratio >= 0.5
+            ? AppColors.warning
+            : AppColors.error;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              '参加可能率',
+              style: TextStyle(
+                fontSize: 11,
+                color: AppColors.textHint,
+              ),
+            ),
+            const Spacer(),
+            Text(
+              '${(ratio * 100).round()}%',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: ratio,
+            backgroundColor: AppColors.surfaceVariant,
+            color: color,
+            minHeight: 6,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/group/group_providers_test.dart
+++ b/test/features/group/group_providers_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     test('createGroup adds a group', () {
       final notifier = container.read(localGroupsProvider.notifier);
-      final group = notifier.createGroup(name: 'テストグループ');
+      notifier.createGroup(name: 'テストグループ');
 
       final groups = container.read(localGroupsProvider);
       expect(groups, hasLength(1));

--- a/test/features/suggestion/suggestion_engine_test.dart
+++ b/test/features/suggestion/suggestion_engine_test.dart
@@ -1,0 +1,278 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:himatch/features/suggestion/domain/suggestion_engine.dart';
+
+void main() {
+  late SuggestionEngine engine;
+
+  setUp(() {
+    engine = SuggestionEngine();
+  });
+
+  Schedule makeSchedule({
+    required String userId,
+    required ScheduleType type,
+    required DateTime startTime,
+    required DateTime endTime,
+    bool isAllDay = false,
+  }) {
+    return Schedule(
+      id: 'test-${startTime.toIso8601String()}',
+      userId: userId,
+      title: 'Test',
+      scheduleType: type,
+      startTime: startTime,
+      endTime: endTime,
+      isAllDay: isAllDay,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  group('SuggestionEngine', () {
+    test('returns empty when fewer than 2 members', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {'user1': []},
+        groupId: 'group1',
+      );
+      expect(result, isEmpty);
+    });
+
+    test('returns empty for empty member map', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {},
+        groupId: 'group1',
+      );
+      expect(result, isEmpty);
+    });
+
+    test('generates suggestions when all members are free', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 3,
+      );
+      expect(result, isNotEmpty);
+      // All suggestions should have 100% availability
+      for (final s in result) {
+        expect(s.availabilityRatio, 1.0);
+        expect(s.availableMembers.length, 2);
+        expect(s.totalMembers, 2);
+      }
+    });
+
+    test('generates suggestions with blocked time excluded', () {
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      final date = DateTime(tomorrow.year, tomorrow.month, tomorrow.day);
+
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [
+            makeSchedule(
+              userId: 'user1',
+              type: ScheduleType.shift,
+              startTime: DateTime(date.year, date.month, date.day, 9, 0),
+              endTime: DateTime(date.year, date.month, date.day, 17, 0),
+            ),
+          ],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 1,
+      );
+
+      // user1 is blocked 9-17, so only 8-9 and 17-22 are available
+      // At least some suggestions should show only partial availability
+      final fullAvail = result.where((s) => s.availabilityRatio == 1.0);
+      final partialAvail = result.where((s) => s.availabilityRatio < 1.0);
+
+      // user1 blocked 9-17 means 8-9 (1h) and 17-22 (5h) both members free
+      // 9-17 only user2 free → partial
+      expect(fullAvail.isNotEmpty || partialAvail.isNotEmpty, true);
+    });
+
+    test('free schedule type marks time as available', () {
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      final date = DateTime(tomorrow.year, tomorrow.month, tomorrow.day);
+
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [
+            makeSchedule(
+              userId: 'user1',
+              type: ScheduleType.free,
+              startTime: DateTime(date.year, date.month, date.day, 10, 0),
+              endTime: DateTime(date.year, date.month, date.day, 15, 0),
+            ),
+          ],
+          'user2': [
+            makeSchedule(
+              userId: 'user2',
+              type: ScheduleType.free,
+              startTime: DateTime(date.year, date.month, date.day, 12, 0),
+              endTime: DateTime(date.year, date.month, date.day, 18, 0),
+            ),
+          ],
+        },
+        groupId: 'group1',
+        searchRangeDays: 1,
+      );
+
+      // Both free 12-15, so should have overlapping suggestion
+      final overlapping = result.where((s) =>
+          s.availabilityRatio == 1.0 &&
+          s.startTime.hour >= 12 &&
+          s.endTime.hour <= 15);
+      expect(overlapping, isNotEmpty);
+    });
+
+    test('all-day blocked schedule blocks entire day', () {
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      final date = DateTime(tomorrow.year, tomorrow.month, tomorrow.day);
+
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [
+            makeSchedule(
+              userId: 'user1',
+              type: ScheduleType.blocked,
+              startTime: DateTime(date.year, date.month, date.day),
+              endTime: DateTime(date.year, date.month, date.day, 23, 59),
+              isAllDay: true,
+            ),
+          ],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 1,
+      );
+
+      // user1 is blocked all day, no full-availability suggestions
+      final fullAvail = result.where((s) => s.availabilityRatio == 1.0);
+      expect(fullAvail, isEmpty);
+    });
+
+    test('suggestions are sorted by score descending', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+          'user3': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 7,
+      );
+
+      for (int i = 0; i < result.length - 1; i++) {
+        if (result[i].score == result[i + 1].score) {
+          // Same score: sorted by date ascending
+          expect(
+            result[i].suggestedDate.compareTo(result[i + 1].suggestedDate) <= 0,
+            true,
+          );
+        } else {
+          expect(result[i].score >= result[i + 1].score, true);
+        }
+      }
+    });
+
+    test('suggestion has valid timeCategory', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 3,
+      );
+
+      for (final s in result) {
+        expect(TimeCategory.values.contains(s.timeCategory), true);
+      }
+    });
+
+    test('suggestion has non-empty activityType', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 3,
+      );
+
+      for (final s in result) {
+        expect(s.activityType, isNotEmpty);
+      }
+    });
+
+    test('suggestion score is between 0 and 1', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 7,
+      );
+
+      for (final s in result) {
+        expect(s.score, greaterThanOrEqualTo(0.0));
+        expect(s.score, lessThanOrEqualTo(1.0));
+      }
+    });
+
+    test('suggestion expires after suggested date', () {
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [],
+          'user2': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 3,
+      );
+
+      for (final s in result) {
+        expect(s.expiresAt.isAfter(s.suggestedDate), true);
+      }
+    });
+
+    test('3 members with partial overlap', () {
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      final date = DateTime(tomorrow.year, tomorrow.month, tomorrow.day);
+
+      final result = engine.generateSuggestions(
+        memberSchedules: {
+          'user1': [
+            makeSchedule(
+              userId: 'user1',
+              type: ScheduleType.shift,
+              startTime: DateTime(date.year, date.month, date.day, 8, 0),
+              endTime: DateTime(date.year, date.month, date.day, 12, 0),
+            ),
+          ],
+          'user2': [
+            makeSchedule(
+              userId: 'user2',
+              type: ScheduleType.event,
+              startTime: DateTime(date.year, date.month, date.day, 14, 0),
+              endTime: DateTime(date.year, date.month, date.day, 18, 0),
+            ),
+          ],
+          'user3': [],
+        },
+        groupId: 'group1',
+        searchRangeDays: 1,
+      );
+
+      // user1 free: 12-22, user2 free: 8-14 & 18-22, user3 free: 8-22
+      // All 3 free: 12-14, 18-22
+      final fullAvail = result.where((s) => s.availabilityRatio == 1.0);
+      expect(fullAvail, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **SuggestionEngine**: Himatchのコア機能。グループメンバーのスケジュールを分析し、空き時間の重複を30分解像度で検出
  - free スケジュールは空き時間として、shift/event/blocked は除外
  - TimeCategory 自動分類 (朝/昼/午後/夜/終日)
  - ActivityType 推定 (時間帯×曜日: ランチ/飲み会/カフェ/日帰り旅行 等)
  - スコアリング: 可用率50% + 時間長20% + 週末10% + 時間帯15%
- **SuggestionsTab**: 候補日カード一覧UI
  - スコアバッジ (色分け: 70%↑緑/40%↑黄/他灰)
  - 参加可能率プログレスバー
  - Accept/Decline ボタンでステータス変更
  - 3つの空状態: グループ未参加/候補なし/候補あり
- **LocalSuggestionsNotifier**: 「更新」ボタンでエンジン実行

## Test plan
- [x] flutter analyze: No issues found
- [x] flutter test: 35/35 passed (既存23 + 新規12)
- [ ] グループ未参加時 → 「グループに参加しましょう」表示
- [ ] グループ参加 + 更新ボタン → 候補日カード生成
- [ ] 候補日カードの承認/見送り操作
- [ ] メンバーのスケジュールが blocked の場合、その時間帯が除外される

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)