### PR TITLE
feat(#17): マイページUI実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 提案カード操作: 承認 (Accept) / 見送り (Decline) ステータス変更
 - ローカル提案状態管理 (LocalSuggestionsNotifier)
 - 提案エンジンテスト (12テスト)
+- マイページUI (ProfileTab): プロフィール表示 + 設定 + アカウント管理
+  - プロフィールヘッダー (アバター/表示名編集/グループ数・スケジュール数)
+  - 設定: 通知ON/OFF、デフォルト公開範囲 (全員/友達/自分)
+  - アカウント: ログアウト (確認ダイアログ付き)
+  - アプリ情報: バージョン/利用規約/プライバシーポリシー
+- 全4タブのプレースホルダー完全差替 (HomeScreen にプレースホルダーなし)

--- a/lib/features/profile/presentation/profile_tab.dart
+++ b/lib/features/profile/presentation/profile_tab.dart
@@ -1,0 +1,380 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/features/profile/presentation/providers/profile_providers.dart';
+import 'package:himatch/features/group/presentation/providers/group_providers.dart';
+import 'package:himatch/features/schedule/presentation/providers/calendar_providers.dart';
+
+class ProfileTab extends ConsumerWidget {
+  const ProfileTab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(profileSettingsProvider);
+    final groups = ref.watch(localGroupsProvider);
+    final schedules = ref.watch(localSchedulesProvider);
+
+    return Scaffold(
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Profile header
+          _ProfileHeader(
+            displayName: settings.displayName,
+            groupCount: groups.length,
+            scheduleCount: schedules.length,
+            onNameTap: () => _showEditNameDialog(context, ref, settings),
+          ),
+          const SizedBox(height: 24),
+
+          // Settings section
+          _SectionHeader(title: '設定'),
+          const SizedBox(height: 8),
+          _SettingsCard(
+            children: [
+              SwitchListTile(
+                title: const Text('通知'),
+                subtitle: const Text('候補日提案の通知を受け取る'),
+                value: settings.notificationsEnabled,
+                onChanged: (_) {
+                  ref
+                      .read(profileSettingsProvider.notifier)
+                      .toggleNotifications();
+                },
+                activeThumbColor: AppColors.primary,
+                secondary: const Icon(Icons.notifications_outlined),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.visibility_outlined),
+                title: const Text('デフォルト公開範囲'),
+                subtitle: Text(_visibilityLabel(settings.defaultVisibility)),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _showVisibilityPicker(context, ref, settings),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // Account section
+          _SectionHeader(title: 'アカウント'),
+          const SizedBox(height: 8),
+          _SettingsCard(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.logout, color: AppColors.error),
+                title: const Text('ログアウト',
+                    style: TextStyle(color: AppColors.error)),
+                onTap: () => _showLogoutDialog(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // App info section
+          _SectionHeader(title: 'アプリ情報'),
+          const SizedBox(height: 8),
+          _SettingsCard(
+            children: [
+              const ListTile(
+                leading: Icon(Icons.info_outline),
+                title: Text('バージョン'),
+                trailing: Text('0.1.0',
+                    style: TextStyle(color: AppColors.textSecondary)),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.description_outlined),
+                title: const Text('利用規約'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  // TODO: Navigate to terms
+                },
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.privacy_tip_outlined),
+                title: const Text('プライバシーポリシー'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  // TODO: Navigate to privacy policy
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+
+          // App name footer
+          const Center(
+            child: Text(
+              'Himatch',
+              style: TextStyle(
+                color: AppColors.textHint,
+                fontSize: 12,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  String _visibilityLabel(String visibility) {
+    return switch (visibility) {
+      'public' => '全員に公開',
+      'friends' => '友達のみ',
+      'private' => '自分のみ',
+      _ => visibility,
+    };
+  }
+
+  Future<void> _showEditNameDialog(
+    BuildContext context,
+    WidgetRef ref,
+    ProfileSettings settings,
+  ) async {
+    final controller = TextEditingController(text: settings.displayName);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('表示名を変更'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: '表示名',
+            hintText: '名前を入力',
+          ),
+          autofocus: true,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+            child: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result != null && result.isNotEmpty && context.mounted) {
+      ref.read(profileSettingsProvider.notifier).updateDisplayName(result);
+    }
+  }
+
+  void _showVisibilityPicker(
+    BuildContext context,
+    WidgetRef ref,
+    ProfileSettings settings,
+  ) {
+    showDialog(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: const Text('デフォルト公開範囲'),
+        children: [
+          for (final option in ['public', 'friends', 'private'])
+            ListTile(
+              leading: Icon(
+                option == settings.defaultVisibility
+                    ? Icons.radio_button_checked
+                    : Icons.radio_button_unchecked,
+                color: option == settings.defaultVisibility
+                    ? AppColors.primary
+                    : AppColors.textHint,
+              ),
+              title: Text(_visibilityLabel(option)),
+              onTap: () {
+                ref
+                    .read(profileSettingsProvider.notifier)
+                    .setDefaultVisibility(option);
+                Navigator.pop(ctx);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _showLogoutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('ログアウト'),
+        content: const Text('ログアウトしますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+              // TODO: Actual logout via AuthService
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('ログアウトしました（デモ）')),
+              );
+            },
+            child: const Text('ログアウト',
+                style: TextStyle(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileHeader extends StatelessWidget {
+  final String displayName;
+  final int groupCount;
+  final int scheduleCount;
+  final VoidCallback onNameTap;
+
+  const _ProfileHeader({
+    required this.displayName,
+    required this.groupCount,
+    required this.scheduleCount,
+    required this.onNameTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            // Avatar
+            CircleAvatar(
+              radius: 40,
+              backgroundColor: AppColors.primaryLight.withValues(alpha: 0.3),
+              child: Text(
+                displayName.isNotEmpty ? displayName[0] : '?',
+                style: const TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.primary,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            // Name
+            GestureDetector(
+              onTap: onNameTap,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    displayName,
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  const Icon(Icons.edit, size: 16, color: AppColors.textHint),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Stats
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _StatItem(
+                  icon: Icons.group,
+                  count: groupCount,
+                  label: 'グループ',
+                ),
+                Container(
+                  width: 1,
+                  height: 32,
+                  color: AppColors.surfaceVariant,
+                ),
+                _StatItem(
+                  icon: Icons.calendar_month,
+                  count: scheduleCount,
+                  label: 'スケジュール',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  final IconData icon;
+  final int count;
+  final String label;
+
+  const _StatItem({
+    required this.icon,
+    required this.count,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Icon(icon, size: 16, color: AppColors.primary),
+            const SizedBox(width: 4),
+            Text(
+              '$count',
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColors.primary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 2),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            color: AppColors.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: AppColors.textSecondary,
+          ),
+    );
+  }
+}
+
+class _SettingsCard extends StatelessWidget {
+  final List<Widget> children;
+
+  const _SettingsCard({required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(children: children),
+    );
+  }
+}

--- a/lib/features/profile/presentation/providers/profile_providers.dart
+++ b/lib/features/profile/presentation/providers/profile_providers.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Local profile settings for offline-first development.
+/// Will be replaced with Supabase-backed + SharedPreferences when connected.
+
+class ProfileSettings {
+  final String displayName;
+  final String? avatarUrl;
+  final bool notificationsEnabled;
+  final String defaultVisibility; // 'public', 'friends', 'private'
+
+  const ProfileSettings({
+    this.displayName = 'ユーザー',
+    this.avatarUrl,
+    this.notificationsEnabled = true,
+    this.defaultVisibility = 'friends',
+  });
+
+  ProfileSettings copyWith({
+    String? displayName,
+    String? avatarUrl,
+    bool? notificationsEnabled,
+    String? defaultVisibility,
+  }) {
+    return ProfileSettings(
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      defaultVisibility: defaultVisibility ?? this.defaultVisibility,
+    );
+  }
+}
+
+final profileSettingsProvider =
+    NotifierProvider<ProfileSettingsNotifier, ProfileSettings>(
+  ProfileSettingsNotifier.new,
+);
+
+class ProfileSettingsNotifier extends Notifier<ProfileSettings> {
+  @override
+  ProfileSettings build() => const ProfileSettings();
+
+  void updateDisplayName(String name) {
+    state = state.copyWith(displayName: name);
+  }
+
+  void toggleNotifications() {
+    state = state.copyWith(
+        notificationsEnabled: !state.notificationsEnabled);
+  }
+
+  void setDefaultVisibility(String visibility) {
+    state = state.copyWith(defaultVisibility: visibility);
+  }
+}

--- a/lib/features/schedule/presentation/home_screen.dart
+++ b/lib/features/schedule/presentation/home_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:himatch/core/theme/app_theme.dart';
 import 'package:himatch/features/schedule/presentation/calendar_tab.dart';
 import 'package:himatch/features/group/presentation/groups_tab.dart';
 import 'package:himatch/features/suggestion/presentation/suggestions_tab.dart';
+import 'package:himatch/features/profile/presentation/profile_tab.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -43,7 +43,7 @@ class _HomeScreenState extends State<HomeScreen> {
           CalendarTab(),
           SuggestionsTab(),
           GroupsTab(),
-          _ProfileTab(),
+          ProfileTab(),
         ],
       ),
       bottomNavigationBar: NavigationBar(
@@ -71,31 +71,6 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.person_outline),
             selectedIcon: Icon(Icons.person),
             label: 'マイページ',
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-
-
-class _ProfileTab extends StatelessWidget {
-  const _ProfileTab();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(Icons.person, size: 64, color: AppColors.primary),
-          SizedBox(height: 16),
-          Text('マイページ', style: TextStyle(fontSize: 18)),
-          SizedBox(height: 8),
-          Text(
-            'プロフィールと設定',
-            style: TextStyle(color: AppColors.textSecondary),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- ProfileTab: プロフィールヘッダー (アバター/表示名編集/グループ数・スケジュール数)
- 設定: 通知ON/OFF トグル、デフォルト公開範囲選択 (全員/友達/自分)
- アカウント: ログアウト (確認ダイアログ)
- アプリ情報: バージョン 0.1.0 / 利用規約 / プライバシーポリシー (リンクTODO)
- ProfileSettingsNotifier: ローカル設定状態管理
- HomeScreen の全4タブからプレースホルダーを完全除去

**これにより MVP の全画面 UI が完成:**
1. カレンダー (CalendarTab) ✅
2. 提案 (SuggestionsTab) ✅
3. グループ (GroupsTab) ✅
4. マイページ (ProfileTab) ✅

## Test plan
- [x] flutter analyze: No issues found
- [x] flutter test: 35/35 passed
- [ ] プロフィールヘッダーに表示名/グループ数/スケジュール数が表示される
- [ ] 表示名タップで編集ダイアログが開く
- [ ] 通知トグルで ON/OFF が切り替わる
- [ ] 公開範囲選択で「全員/友達/自分」が選べる
- [ ] ログアウト確認ダイアログ表示

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)