### PR TITLE
feat(#19): デモモード & 認証フロー統合

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Supabase credentials
+# Run with: flutter run --dart-define=SUPABASE_URL=https://xxx.supabase.co --dart-define=SUPABASE_ANON_KEY=xxx
+#
+# Without these, the app runs in demo mode only.
+SUPABASE_URL=
+SUPABASE_ANON_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - アカウント: ログアウト (確認ダイアログ付き)
   - アプリ情報: バージョン/利用規約/プライバシーポリシー
 - 全4タブのプレースホルダー完全差替 (HomeScreen にプレースホルダーなし)
+- デモモード認証: ログイン画面「デモモードで始める」でSupabase未接続でも全機能操作可能
+- AuthNotifier: 統合認証状態管理 (none/demo/supabase モード)
+- go_router: AuthNotifier ベースのリダイレクトに移行
+- main.dart: Supabase 初期化の安全化 (未設定時・接続失敗時もクラッシュしない)
+- ProfileTab: デモモードバナー表示 + ログアウトで AuthNotifier.signOut
+- .env.example: Supabase 環境変数テンプレート
+- 認証テスト (4テスト)

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 
-class LoginScreen extends StatelessWidget {
+class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -14,7 +16,7 @@ class LoginScreen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               const Spacer(flex: 2),
-              // App icon placeholder
+              // App icon
               Container(
                 width: 120,
                 height: 120,
@@ -44,13 +46,18 @@ class LoginScreen extends StatelessWidget {
                     ),
               ),
               const Spacer(flex: 2),
-              // Apple Sign In button
+              // Apple Sign In
               SizedBox(
                 width: double.infinity,
                 height: 52,
                 child: ElevatedButton.icon(
                   onPressed: () {
-                    // TODO: Implement Apple Sign In
+                    // TODO: Implement Apple Sign In with Supabase
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Apple サインインは Supabase 接続後に有効になります'),
+                      ),
+                    );
                   },
                   icon: const Icon(Icons.apple, size: 24),
                   label: const Text('Appleでサインイン'),
@@ -64,13 +71,18 @@ class LoginScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 12),
-              // Google Sign In button
+              // Google Sign In
               SizedBox(
                 width: double.infinity,
                 height: 52,
                 child: OutlinedButton.icon(
                   onPressed: () {
-                    // TODO: Implement Google Sign In
+                    // TODO: Implement Google Sign In with Supabase
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Google サインインは Supabase 接続後に有効になります'),
+                      ),
+                    );
                   },
                   icon: const Icon(Icons.g_mobiledata, size: 28),
                   label: const Text('Googleでサインイン'),
@@ -84,13 +96,18 @@ class LoginScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 12),
-              // LINE Sign In button
+              // LINE Sign In
               SizedBox(
                 width: double.infinity,
                 height: 52,
                 child: ElevatedButton.icon(
                   onPressed: () {
                     // TODO: Implement LINE Login
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('LINE サインインは Supabase 接続後に有効になります'),
+                      ),
+                    );
                   },
                   icon: const Icon(Icons.chat_bubble, size: 22),
                   label: const Text('LINEでサインイン'),
@@ -101,6 +118,45 @@ class LoginScreen extends StatelessWidget {
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              // Divider
+              Row(
+                children: [
+                  const Expanded(child: Divider()),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'または',
+                      style: TextStyle(
+                        color: AppColors.textHint,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  const Expanded(child: Divider()),
+                ],
+              ),
+              const SizedBox(height: 16),
+              // Demo mode
+              SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: TextButton(
+                  onPressed: () {
+                    ref.read(authNotifierProvider.notifier).signInDemo();
+                  },
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColors.textSecondary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      side: BorderSide(
+                        color: AppColors.textHint.withValues(alpha: 0.3),
+                      ),
+                    ),
+                  ),
+                  child: const Text('デモモードで始める'),
                 ),
               ),
               const Spacer(),

--- a/lib/features/auth/providers/auth_providers.dart
+++ b/lib/features/auth/providers/auth_providers.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Unified auth state that works in both demo and Supabase modes.
+enum AuthMode { none, demo, supabase }
+
+class AuthState {
+  final AuthMode mode;
+  final String? userId;
+  final String? displayName;
+
+  const AuthState({
+    this.mode = AuthMode.none,
+    this.userId,
+    this.displayName,
+  });
+
+  bool get isAuthenticated => mode != AuthMode.none;
+  bool get isDemo => mode == AuthMode.demo;
+}
+
+final authNotifierProvider =
+    NotifierProvider<AuthNotifier, AuthState>(AuthNotifier.new);
+
+class AuthNotifier extends Notifier<AuthState> {
+  @override
+  AuthState build() => const AuthState();
+
+  void signInDemo() {
+    state = const AuthState(
+      mode: AuthMode.demo,
+      userId: 'local-user',
+      displayName: 'デモユーザー',
+    );
+  }
+
+  void signOut() {
+    state = const AuthState();
+  }
+
+  // Will be extended for Supabase auth in future
+  void signInWithSupabase({
+    required String userId,
+    required String displayName,
+  }) {
+    state = AuthState(
+      mode: AuthMode.supabase,
+      userId: userId,
+      displayName: displayName,
+    );
+  }
+}

--- a/lib/features/profile/presentation/profile_tab.dart
+++ b/lib/features/profile/presentation/profile_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:himatch/core/theme/app_theme.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/features/profile/presentation/providers/profile_providers.dart';
 import 'package:himatch/features/group/presentation/providers/group_providers.dart';
 import 'package:himatch/features/schedule/presentation/providers/calendar_providers.dart';
@@ -10,6 +11,7 @@ class ProfileTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authNotifierProvider);
     final settings = ref.watch(profileSettingsProvider);
     final groups = ref.watch(localGroupsProvider);
     final schedules = ref.watch(localSchedulesProvider);
@@ -18,9 +20,33 @@ class ProfileTab extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          // Demo mode banner
+          if (authState.isDemo)
+            Container(
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: AppColors.warning.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Row(
+                children: [
+                  Icon(Icons.science, size: 16, color: AppColors.warning),
+                  SizedBox(width: 8),
+                  Text(
+                    'デモモードで動作中',
+                    style: TextStyle(
+                      color: AppColors.warning,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           // Profile header
           _ProfileHeader(
-            displayName: settings.displayName,
+            displayName: authState.displayName ?? settings.displayName,
             groupCount: groups.length,
             scheduleCount: schedules.length,
             onNameTap: () => _showEditNameDialog(context, ref, settings),
@@ -65,7 +91,7 @@ class ProfileTab extends ConsumerWidget {
                 leading: const Icon(Icons.logout, color: AppColors.error),
                 title: const Text('ログアウト',
                     style: TextStyle(color: AppColors.error)),
-                onTap: () => _showLogoutDialog(context),
+                onTap: () => _showLogoutDialog(context, ref),
               ),
             ],
           ),
@@ -198,7 +224,7 @@ class ProfileTab extends ConsumerWidget {
     );
   }
 
-  void _showLogoutDialog(BuildContext context) {
+  void _showLogoutDialog(BuildContext context, WidgetRef ref) {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -212,10 +238,7 @@ class ProfileTab extends ConsumerWidget {
           TextButton(
             onPressed: () {
               Navigator.pop(ctx);
-              // TODO: Actual logout via AuthService
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('ログアウトしました（デモ）')),
-              );
+              ref.read(authNotifierProvider.notifier).signOut();
             },
             child: const Text('ログアウト',
                 style: TextStyle(color: AppColors.error)),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,12 +6,23 @@ import 'package:himatch/app.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await Supabase.initialize(
-    url: const String.fromEnvironment('SUPABASE_URL',
-        defaultValue: 'https://placeholder.supabase.co'),
-    anonKey: const String.fromEnvironment('SUPABASE_ANON_KEY',
-        defaultValue: 'placeholder-key'),
-  );
+  // Supabase initialization (safe: skip if placeholder URL)
+  const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+  const supabaseAnonKey = String.fromEnvironment('SUPABASE_ANON_KEY');
+
+  if (supabaseUrl.isNotEmpty && supabaseAnonKey.isNotEmpty) {
+    try {
+      await Supabase.initialize(
+        url: supabaseUrl,
+        anonKey: supabaseAnonKey,
+      );
+    } catch (e) {
+      debugPrint('Supabase initialization failed: $e');
+      debugPrint('Running in demo mode only.');
+    }
+  } else {
+    debugPrint('No Supabase credentials. Running in demo mode.');
+  }
 
   runApp(
     const ProviderScope(

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -1,16 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:himatch/features/auth/presentation/login_screen.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/features/schedule/presentation/home_screen.dart';
-import 'package:himatch/services/auth_service.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
-  final user = ref.watch(currentUserProvider);
+  final authState = ref.watch(authNotifierProvider);
 
   return GoRouter(
     initialLocation: '/',
     redirect: (context, state) {
-      final isLoggedIn = user != null;
+      final isLoggedIn = authState.isAuthenticated;
       final isOnLogin = state.matchedLocation == '/login';
 
       if (!isLoggedIn && !isOnLogin) return '/login';

--- a/test/features/auth/auth_providers_test.dart
+++ b/test/features/auth/auth_providers_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('AuthNotifier', () {
+    test('initial state is not authenticated', () {
+      final state = container.read(authNotifierProvider);
+      expect(state.isAuthenticated, false);
+      expect(state.mode, AuthMode.none);
+      expect(state.userId, isNull);
+    });
+
+    test('signInDemo sets demo mode', () {
+      container.read(authNotifierProvider.notifier).signInDemo();
+
+      final state = container.read(authNotifierProvider);
+      expect(state.isAuthenticated, true);
+      expect(state.isDemo, true);
+      expect(state.mode, AuthMode.demo);
+      expect(state.userId, 'local-user');
+      expect(state.displayName, 'デモユーザー');
+    });
+
+    test('signOut resets to unauthenticated', () {
+      container.read(authNotifierProvider.notifier).signInDemo();
+      expect(container.read(authNotifierProvider).isAuthenticated, true);
+
+      container.read(authNotifierProvider.notifier).signOut();
+
+      final state = container.read(authNotifierProvider);
+      expect(state.isAuthenticated, false);
+      expect(state.mode, AuthMode.none);
+      expect(state.userId, isNull);
+    });
+
+    test('signInWithSupabase sets supabase mode', () {
+      container.read(authNotifierProvider.notifier).signInWithSupabase(
+            userId: 'supabase-user-123',
+            displayName: 'テストユーザー',
+          );
+
+      final state = container.read(authNotifierProvider);
+      expect(state.isAuthenticated, true);
+      expect(state.isDemo, false);
+      expect(state.mode, AuthMode.supabase);
+      expect(state.userId, 'supabase-user-123');
+      expect(state.displayName, 'テストユーザー');
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -17,5 +17,6 @@ void main() {
     expect(find.text('Appleでサインイン'), findsOneWidget);
     expect(find.text('Googleでサインイン'), findsOneWidget);
     expect(find.text('LINEでサインイン'), findsOneWidget);
+    expect(find.text('デモモードで始める'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- **AuthNotifier**: 統合認証状態管理 (none/demo/supabase の3モード)
- **LoginScreen**: 「デモモードで始める」ボタン追加 → Supabase 未接続でも全機能操作可能
- **go_router**: `currentUserProvider` (Supabase直接) → `authNotifierProvider` に移行
- **main.dart**: Supabase 初期化の安全化 (環境変数未設定 or 接続失敗でもクラッシュしない)
- **ProfileTab**: デモモードバナー表示 + ログアウトで `authNotifier.signOut()` → ログイン画面に戻る
- **.env.example**: `dart-define` による環境変数テンプレート

**これにより、アプリが完全に操作可能になりました：**
ログイン画面 → デモモードで始める → 全4タブ操作 → ログアウト → ログイン画面に戻る

## Test plan
- [x] flutter analyze: No issues found
- [x] flutter test: 39/39 passed (既存35 + 新規4)
- [ ] ログイン画面で「デモモードで始める」→ HomeScreen に遷移
- [ ] HomeScreen の全4タブが操作可能
- [ ] マイページ → ログアウト → ログイン画面に戻る
- [ ] Apple/Google/LINE ボタンタップ → SnackBar 表示（未接続通知）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)