### PR TITLE
feat(#23): 候補日の投票・確定フロー

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ProfileTab: デモモードバナー表示 + ログアウトで AuthNotifier.signOut
 - .env.example: Supabase 環境変数テンプレート
 - 認証テスト (4テスト)
+- 投票・確定フロー: 候補日に対してメンバーが「参加OK」「微妙」「NG」の3択で投票
+  - Vote モデル (Freezed): userId + suggestionId + voteType (ok/maybe/ng) + displayName
+  - LocalVotesNotifier: castVote (投票/再投票)、getUserVote、getVoteSummary、clearVotes
+  - SuggestionStatus.confirmed: グループオーナーが「この日に決定」で確定
+  - confirmSuggestion: 確定時に同グループの他候補を自動 decline
+  - 投票UI: 3色ボタン (緑=OK, 黄=微妙, 赤=NG) + 選択状態のハイライト
+  - 投票集計表示: OK/微妙/NG カウント + スタックドバー + 投票者名タグ
+  - 確定ボタン: グループオーナーかつ投票あり時のみ表示 + 確認ダイアログ
+  - 確定済み候補: 緑ボーダー + 「予定確定！」セレブレーション表示
+  - セクション分類: 確定済み / 投票受付中 / 承認済み で候補を整理表示
+- 投票テスト (14テスト): Vote モデル、VotesNotifier CRUD、VoteSummary

--- a/lib/features/suggestion/presentation/providers/suggestion_providers.dart
+++ b/lib/features/suggestion/presentation/providers/suggestion_providers.dart
@@ -68,6 +68,25 @@ class LocalSuggestionsNotifier extends Notifier<List<Suggestion>> {
     ];
   }
 
+  /// Confirm a suggestion (group owner action).
+  /// Sets this suggestion to confirmed and declines other proposed suggestions
+  /// for the same group on the same date.
+  void confirmSuggestion(String id) {
+    final target = state.where((s) => s.id == id).firstOrNull;
+    if (target == null) return;
+
+    state = [
+      for (final s in state)
+        if (s.id == id)
+          s.copyWith(status: SuggestionStatus.confirmed)
+        else if (s.groupId == target.groupId &&
+            s.status == SuggestionStatus.proposed)
+          s.copyWith(status: SuggestionStatus.declined)
+        else
+          s,
+    ];
+  }
+
   void clear() {
     state = [];
   }

--- a/lib/features/suggestion/presentation/providers/vote_providers.dart
+++ b/lib/features/suggestion/presentation/providers/vote_providers.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/models/vote.dart';
+import 'package:uuid/uuid.dart';
+
+/// Local vote state for offline-first development.
+/// Key: suggestionId, Value: list of votes for that suggestion.
+final localVotesProvider =
+    NotifierProvider<LocalVotesNotifier, Map<String, List<Vote>>>(
+  LocalVotesNotifier.new,
+);
+
+class LocalVotesNotifier extends Notifier<Map<String, List<Vote>>> {
+  static const _uuid = Uuid();
+
+  @override
+  Map<String, List<Vote>> build() => {};
+
+  /// Cast or update a vote on a suggestion.
+  void castVote({
+    required String suggestionId,
+    required String userId,
+    required VoteType voteType,
+    String? displayName,
+  }) {
+    final currentVotes = List<Vote>.from(state[suggestionId] ?? []);
+
+    // Remove existing vote by this user
+    currentVotes.removeWhere((v) => v.userId == userId);
+
+    // Add new vote
+    currentVotes.add(Vote(
+      id: _uuid.v4(),
+      suggestionId: suggestionId,
+      userId: userId,
+      displayName: displayName,
+      voteType: voteType,
+      votedAt: DateTime.now(),
+    ));
+
+    state = {...state, suggestionId: currentVotes};
+  }
+
+  /// Get current user's vote for a suggestion.
+  VoteType? getUserVote(String suggestionId, String userId) {
+    final votes = state[suggestionId] ?? [];
+    final userVote = votes.where((v) => v.userId == userId).firstOrNull;
+    return userVote?.voteType;
+  }
+
+  /// Get vote summary for a suggestion.
+  VoteSummary getVoteSummary(String suggestionId) {
+    final votes = state[suggestionId] ?? [];
+    return VoteSummary(
+      okCount: votes.where((v) => v.voteType == VoteType.ok).length,
+      maybeCount: votes.where((v) => v.voteType == VoteType.maybe).length,
+      ngCount: votes.where((v) => v.voteType == VoteType.ng).length,
+      votes: votes,
+    );
+  }
+
+  /// Clear all votes for a suggestion.
+  void clearVotes(String suggestionId) {
+    final updated = Map<String, List<Vote>>.from(state);
+    updated.remove(suggestionId);
+    state = updated;
+  }
+}
+
+/// Summary of votes for display.
+class VoteSummary {
+  final int okCount;
+  final int maybeCount;
+  final int ngCount;
+  final List<Vote> votes;
+
+  const VoteSummary({
+    required this.okCount,
+    required this.maybeCount,
+    required this.ngCount,
+    required this.votes,
+  });
+
+  int get totalVotes => okCount + maybeCount + ngCount;
+  bool get hasVotes => totalVotes > 0;
+}

--- a/lib/models/suggestion.dart
+++ b/lib/models/suggestion.dart
@@ -23,6 +23,8 @@ enum SuggestionStatus {
   accepted,
   @JsonValue('declined')
   declined,
+  @JsonValue('confirmed')
+  confirmed,
   @JsonValue('expired')
   expired,
 }

--- a/lib/models/vote.dart
+++ b/lib/models/vote.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'vote.freezed.dart';
+part 'vote.g.dart';
+
+enum VoteType {
+  @JsonValue('ok')
+  ok,
+  @JsonValue('maybe')
+  maybe,
+  @JsonValue('ng')
+  ng,
+}
+
+@freezed
+abstract class Vote with _$Vote {
+  const factory Vote({
+    required String id,
+    @JsonKey(name: 'suggestion_id') required String suggestionId,
+    @JsonKey(name: 'user_id') required String userId,
+    @JsonKey(name: 'display_name') String? displayName,
+    @JsonKey(name: 'vote_type') required VoteType voteType,
+    @JsonKey(name: 'voted_at') required DateTime votedAt,
+  }) = _Vote;
+
+  factory Vote.fromJson(Map<String, dynamic> json) => _$VoteFromJson(json);
+}

--- a/test/features/suggestion/vote_providers_test.dart
+++ b/test/features/suggestion/vote_providers_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/models/vote.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:himatch/features/suggestion/presentation/providers/vote_providers.dart';
+import 'package:himatch/features/suggestion/presentation/providers/suggestion_providers.dart';
+
+void main() {
+  group('LocalVotesNotifier', () {
+    late ProviderContainer container;
+    late LocalVotesNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      notifier = container.read(localVotesProvider.notifier);
+    });
+
+    tearDown(() => container.dispose());
+
+    test('initial state is empty', () {
+      expect(container.read(localVotesProvider), isEmpty);
+    });
+
+    test('castVote adds a vote', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+        displayName: 'テストユーザー',
+      );
+
+      final votes = container.read(localVotesProvider);
+      expect(votes['sug-1'], hasLength(1));
+      expect(votes['sug-1']!.first.voteType, VoteType.ok);
+      expect(votes['sug-1']!.first.displayName, 'テストユーザー');
+    });
+
+    test('castVote replaces existing vote by same user', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ng,
+      );
+
+      final votes = container.read(localVotesProvider);
+      expect(votes['sug-1'], hasLength(1));
+      expect(votes['sug-1']!.first.voteType, VoteType.ng);
+    });
+
+    test('multiple users can vote on same suggestion', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-2',
+        voteType: VoteType.maybe,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-3',
+        voteType: VoteType.ng,
+      );
+
+      final votes = container.read(localVotesProvider);
+      expect(votes['sug-1'], hasLength(3));
+    });
+
+    test('getUserVote returns correct vote type', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.maybe,
+      );
+
+      expect(notifier.getUserVote('sug-1', 'user-1'), VoteType.maybe);
+      expect(notifier.getUserVote('sug-1', 'user-2'), isNull);
+      expect(notifier.getUserVote('sug-2', 'user-1'), isNull);
+    });
+
+    test('getVoteSummary returns correct counts', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-2',
+        voteType: VoteType.ok,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-3',
+        voteType: VoteType.maybe,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-4',
+        voteType: VoteType.ng,
+      );
+
+      final summary = notifier.getVoteSummary('sug-1');
+      expect(summary.okCount, 2);
+      expect(summary.maybeCount, 1);
+      expect(summary.ngCount, 1);
+      expect(summary.totalVotes, 4);
+      expect(summary.hasVotes, isTrue);
+    });
+
+    test('getVoteSummary for empty suggestion', () {
+      final summary = notifier.getVoteSummary('nonexistent');
+      expect(summary.okCount, 0);
+      expect(summary.maybeCount, 0);
+      expect(summary.ngCount, 0);
+      expect(summary.totalVotes, 0);
+      expect(summary.hasVotes, isFalse);
+    });
+
+    test('clearVotes removes all votes for suggestion', () {
+      notifier.castVote(
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+      );
+      notifier.castVote(
+        suggestionId: 'sug-2',
+        userId: 'user-1',
+        voteType: VoteType.ng,
+      );
+
+      notifier.clearVotes('sug-1');
+
+      final votes = container.read(localVotesProvider);
+      expect(votes.containsKey('sug-1'), isFalse);
+      expect(votes['sug-2'], hasLength(1));
+    });
+  });
+
+  group('SuggestionNotifier.confirmSuggestion', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    test('confirmSuggestion does not crash on empty state', () {
+      final notifier = container.read(localSuggestionsProvider.notifier);
+      notifier.confirmSuggestion('nonexistent');
+      expect(container.read(localSuggestionsProvider), isEmpty);
+    });
+
+    test('confirmed status exists in SuggestionStatus enum', () {
+      expect(SuggestionStatus.confirmed, isNotNull);
+      expect(SuggestionStatus.confirmed.name, 'confirmed');
+    });
+  });
+
+  group('Vote model', () {
+    test('fromJson creates vote correctly', () {
+      final json = {
+        'id': 'vote-1',
+        'suggestion_id': 'sug-1',
+        'user_id': 'user-1',
+        'display_name': 'テストユーザー',
+        'vote_type': 'ok',
+        'voted_at': '2025-03-15T10:00:00.000',
+      };
+
+      final vote = Vote.fromJson(json);
+      expect(vote.id, 'vote-1');
+      expect(vote.suggestionId, 'sug-1');
+      expect(vote.userId, 'user-1');
+      expect(vote.displayName, 'テストユーザー');
+      expect(vote.voteType, VoteType.ok);
+    });
+
+    test('toJson serializes correctly', () {
+      final vote = Vote(
+        id: 'vote-1',
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        displayName: 'テスト',
+        voteType: VoteType.maybe,
+        votedAt: DateTime(2025, 3, 15, 10),
+      );
+
+      final json = vote.toJson();
+      expect(json['suggestion_id'], 'sug-1');
+      expect(json['vote_type'], 'maybe');
+      expect(json['display_name'], 'テスト');
+    });
+
+    test('copyWith works correctly', () {
+      final vote = Vote(
+        id: 'vote-1',
+        suggestionId: 'sug-1',
+        userId: 'user-1',
+        voteType: VoteType.ok,
+        votedAt: DateTime.now(),
+      );
+
+      final updated = vote.copyWith(voteType: VoteType.ng);
+      expect(updated.voteType, VoteType.ng);
+      expect(updated.id, 'vote-1');
+    });
+
+    test('VoteType enum values', () {
+      expect(VoteType.values, hasLength(3));
+      expect(VoteType.ok.name, 'ok');
+      expect(VoteType.maybe.name, 'maybe');
+      expect(VoteType.ng.name, 'ng');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Vote モデル (Freezed) を新規作成: userId + suggestionId + voteType (ok/maybe/ng)
- LocalVotesNotifier: 投票の cast/update/summary/clear を管理
- SuggestionStatus.confirmed を追加、confirmSuggestion() で確定＋他候補自動 decline
- 提案カードUIを全面改修: 3択投票ボタン + 投票集計バー + 投票者タグ + 確定UI
- グループオーナーのみ「この日に決定」ボタンを表示（確認ダイアログ付き）
- セクション分類表示: 確定済み / 投票受付中 / 承認済み

## Test plan

- [x] flutter analyze: No issues found
- [x] flutter test: 53 tests all passing (14 new)
- [ ] デモモードで提案タブ → 投票ボタン3つ表示確認
- [ ] 参加OK / 微妙 / NG ボタンタップで選択状態変化確認
- [ ] 投票後、集計バー + 投票者タグが表示される確認
- [ ] グループオーナーで「この日に決定」ボタン表示 → 確定ダイアログ → 確定確認
- [ ] 確定後、他の候補が decline される確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)