### PR TITLE
feat(#35): 提案タブの候補日を自動生成に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WeatherLocationScreen: 設定UI (GPS切替 + 都市検索 + debounce)
   - WeatherService: 座標変更時のキャッシュ自動無効化
   - iOS/Android 位置情報パーミッション設定
+
+### Changed
+- 提案タブ: 手動「候補日を検索」ボタンを廃止し、タブ表示時に自動で候補日を生成するように変更
+
 - お問い合わせ画面 (ContactScreen): カテゴリ選択・件名・本文のフォーム付き問い合わせ機能
 - 利用規約画面 (TermsOfServiceScreen): 9条構成の利用規約をアプリ内で閲覧可能に
 - プライバシーポリシー画面 (PrivacyPolicyScreen): 個人情報保護法準拠の8項目ポリシーをアプリ内で閲覧可能に

--- a/lib/features/suggestion/presentation/suggestions_tab.dart
+++ b/lib/features/suggestion/presentation/suggestions_tab.dart
@@ -24,6 +24,32 @@ class SuggestionsTab extends ConsumerStatefulWidget {
 class _SuggestionsTabState extends ConsumerState<SuggestionsTab> {
   /// null = 全グループ表示
   String? _selectedGroupId;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _autoRefreshIfNeeded();
+    });
+  }
+
+  Future<void> _autoRefreshIfNeeded() async {
+    final groups = ref.read(localGroupsProvider);
+    final suggestions = ref.read(localSuggestionsProvider);
+    if (groups.isNotEmpty && suggestions.isEmpty) {
+      await _refresh();
+    }
+  }
+
+  Future<void> _refresh() async {
+    if (_isLoading) return;
+    setState(() => _isLoading = true);
+    await ref.read(localSuggestionsProvider.notifier).refreshSuggestions();
+    if (mounted) {
+      setState(() => _isLoading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,24 +77,18 @@ class _SuggestionsTabState extends ConsumerState<SuggestionsTab> {
                 ),
                 // メインコンテンツ
                 Expanded(
-                  child: suggestions.isEmpty
-                      ? _EmptySuggestionState(ref: ref)
-                      : _SuggestionCalendar(suggestions: suggestions),
+                  child: _isLoading
+                      ? const _LoadingState()
+                      : suggestions.isEmpty
+                          ? const _EmptySuggestionState()
+                          : _SuggestionCalendar(suggestions: suggestions),
                 ),
               ],
             ),
-      floatingActionButton: groups.isNotEmpty
+      floatingActionButton: groups.isNotEmpty && !_isLoading
           ? FloatingActionButton.extended(
               onPressed: () async {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('天気情報を取得中...'),
-                    duration: Duration(seconds: 1),
-                  ),
-                );
-                await ref
-                    .read(localSuggestionsProvider.notifier)
-                    .refreshSuggestions();
+                await _refresh();
                 if (context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('候補日を更新しました')),
@@ -184,9 +204,38 @@ class _NoGroupState extends StatelessWidget {
   }
 }
 
+class _LoadingState extends StatelessWidget {
+  const _LoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 24),
+            Text('候補日を検索中...',
+                style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.textSecondary)),
+            SizedBox(height: 8),
+            Text(
+              '天気予報と空き時間を分析しています',
+              style: TextStyle(color: AppColors.textHint, fontSize: 13),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _EmptySuggestionState extends StatelessWidget {
-  final WidgetRef ref;
-  const _EmptySuggestionState({required this.ref});
+  const _EmptySuggestionState();
 
   @override
   Widget build(BuildContext context) {
@@ -206,19 +255,9 @@ class _EmptySuggestionState extends StatelessWidget {
                     color: AppColors.textPrimary)),
             const SizedBox(height: 8),
             const Text(
-              '右下の「更新」ボタンをタップして\n候補日を検索しましょう',
+              'メンバーの空き時間が見つかりませんでした\n右下の「更新」ボタンで再検索できます',
               textAlign: TextAlign.center,
               style: TextStyle(color: AppColors.textSecondary, fontSize: 14),
-            ),
-            const SizedBox(height: 24),
-            OutlinedButton.icon(
-              onPressed: () async {
-                await ref
-                    .read(localSuggestionsProvider.notifier)
-                    .refreshSuggestions();
-              },
-              icon: const Icon(Icons.search),
-              label: const Text('候補日を検索'),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary

- 提案タブ表示時に手動で「候補日を検索」ボタンを押す必要があったのを、自動生成に変更
- グループがあり候補が空の場合、`initState` で自動的に `refreshSuggestions()` を実行
- ローディング中はスピナー + メッセージ表示、FAB は非表示
- FAB の「更新」ボタンは手動リフレッシュ用に残存

Closes #35

## 変更ファイル
- `lib/features/suggestion/presentation/suggestions_tab.dart` — 自動生成ロジック + UI変更
- `CHANGELOG.md`

## Test plan

- [ ] `flutter analyze` — 新規エラー0件
- [ ] 提案タブを開く → ローディング表示 → 候補日が自動表示される
- [ ] 候補0件の場合 → 「メンバーの空き時間が見つかりませんでした」表示
- [ ] FAB「更新」タップ → 手動リフレッシュが動作する
- [ ] ローディング中は FAB が非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)