### PR TITLE
feat(#37): デモモード時の天気デフォルトを福岡市に設定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - 提案タブ: 手動「候補日を検索」ボタンを廃止し、タブ表示時に自動で候補日を生成するように変更
+- デモモード: 天気予報の地域デフォルトを福岡市に設定（設定画面から変更可能）
 
 - お問い合わせ画面 (ContactScreen): カテゴリ選択・件名・本文のフォーム付き問い合わせ機能
 - 利用規約画面 (TermsOfServiceScreen): 9条構成の利用規約をアプリ内で閲覧可能に

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -25,6 +25,8 @@ abstract class AppConstants {
       'https://geocoding-api.open-meteo.com/v1/search';
   static const double defaultLatitude = 35.6762; // Tokyo
   static const double defaultLongitude = 139.6503;
+  static const double demoLatitude = 33.5904; // Fukuoka
+  static const double demoLongitude = 130.4017;
   static const String defaultTimezone = 'Asia/Tokyo';
   static const int weatherForecastDays = 14;
   static const Duration weatherCacheDuration = Duration(hours: 1);

--- a/lib/features/profile/presentation/providers/location_providers.dart
+++ b/lib/features/profile/presentation/providers/location_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:himatch/core/constants/app_constants.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/models/weather_location.dart';
 import 'package:himatch/services/geocoding_service.dart';
 
@@ -12,7 +13,18 @@ final weatherLocationProvider =
 
 class WeatherLocationNotifier extends Notifier<WeatherLocation> {
   @override
-  WeatherLocation build() => const WeatherLocation();
+  WeatherLocation build() {
+    final authState = ref.watch(authNotifierProvider);
+    if (authState.isDemo) {
+      return const WeatherLocation(
+        useCurrentLocation: false,
+        latitude: AppConstants.demoLatitude,
+        longitude: AppConstants.demoLongitude,
+        name: '福岡市',
+      );
+    }
+    return const WeatherLocation();
+  }
 
   /// Switch to GPS-based location.
   void useCurrentLocation() {


### PR DESCRIPTION
## Summary

- デモモード時、天気予報の地域デフォルトを福岡市（33.5904, 130.4017）に設定
- 設定画面から他の都市への変更は引き続き可能
- `AppConstants` に `demoLatitude` / `demoLongitude` を追加

Closes #37

## 変更ファイル
- `lib/core/constants/app_constants.dart` — 福岡の座標定数追加
- `lib/features/profile/presentation/providers/location_providers.dart` — デモモード判定でデフォルト福岡
- `CHANGELOG.md`

## Test plan

- [ ] `flutter analyze` — エラー0件
- [ ] デモモードでログイン → 天気の地域が「福岡市」
- [ ] 設定画面 → 都市変更可能（「大阪」等に変更できる）
- [ ] 通常モード → デフォルトは「現在地 (GPS)」のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)