### PR TITLE
feat(#39): 提案カードに「お誘いを送る」ボタンを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WeatherService: 座標変更時のキャッシュ自動無効化
   - iOS/Android 位置情報パーミッション設定
 
+- 提案カードに「お誘いを送る」ボタン: 候補日の詳細をLINE等で共有可能
+
 ### Changed
 - 提案タブ: 手動「候補日を検索」ボタンを廃止し、タブ表示時に自動で候補日を生成するように変更
 - デモモード: 天気予報の地域デフォルトを福岡市に設定（設定画面から変更可能）

--- a/lib/features/suggestion/presentation/suggestions_tab.dart
+++ b/lib/features/suggestion/presentation/suggestions_tab.dart
@@ -11,6 +11,7 @@ import 'package:himatch/features/suggestion/presentation/providers/vote_provider
 import 'package:himatch/features/group/presentation/providers/group_providers.dart';
 import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/providers/holiday_providers.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:himatch/features/suggestion/presentation/share_card_screen.dart';
 import 'package:himatch/features/suggestion/presentation/public_vote_screen.dart';
 
@@ -961,6 +962,24 @@ class _SuggestionTile extends ConsumerWidget {
             ),
           ],
 
+          // お誘いボタン
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: () => _sendInvite(context),
+              icon: const Icon(Icons.send, size: 14),
+              label: const Text('お誘いを送る'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.primary,
+                side: const BorderSide(color: AppColors.primaryLight),
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                textStyle: const TextStyle(
+                    fontSize: 13, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+
           // 確定表示
           if (isConfirmed) ...[
             const SizedBox(height: 8),
@@ -1026,6 +1045,31 @@ class _SuggestionTile extends ConsumerWidget {
           voteType: voteType,
           displayName: displayName,
         );
+  }
+
+  void _sendInvite(BuildContext context) {
+    final date = AppDateUtils.formatMonthDayWeek(suggestion.suggestedDate);
+    final time =
+        '${AppDateUtils.formatTime(suggestion.startTime)}-${AppDateUtils.formatTime(suggestion.endTime)}';
+    final weather = suggestion.weatherSummary;
+    final weatherLine = weather != null
+        ? '${weather.icon ?? ''} ${weather.condition}'
+            '${weather.tempHigh != null ? ' ${weather.tempHigh!.round()}°/${weather.tempLow!.round()}°' : ''}'
+        : null;
+
+    final lines = <String>[
+      '一緒に遊ぼう！',
+      '',
+      date,
+      suggestion.activityType,
+      time,
+      ?weatherLine,
+      ?groupName,
+      '',
+      'Himatchで予定を確認してね！',
+    ];
+
+    SharePlus.instance.share(ShareParams(text: lines.join('\n')));
   }
 
   void _confirmSuggestion(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
## Summary

- 提案ボトムシートの候補カードに「お誘いを送る」ボタンを追加
- タップで share_plus のシェアシートが開き、LINE等でお誘いメッセージを送信可能
- メッセージ例:
  ```
  一緒に遊ぼう！

  2/27 (金)
  BBQ
  09:00-17:00
  ☁️ くもり 13°/7°
  バイト仲間

  Himatchで予定を確認してね！
  ```

Closes #39

## 変更ファイル
- `lib/features/suggestion/presentation/suggestions_tab.dart` — お誘いボタン + `_sendInvite()` 追加
- `CHANGELOG.md`

## Test plan

- [ ] `flutter analyze` — エラー0件
- [ ] 提案タブ → 日付タップ → カードの「お誘いを送る」ボタンタップ → シェアシート表示
- [ ] メッセージに日付・アクティビティ・時間・天気・グループ名が含まれる
- [ ] 投票ボタン（OK/微妙/NG）は引き続き動作
- [ ] 確定済みカードでもお誘いボタンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)