### PR TITLE
feat(#41): お誘い送信先の選択機能（チャット/アンケート/外部共有）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WeatherService: 座標変更時のキャッシュ自動無効化
   - iOS/Android 位置情報パーミッション設定
 
-- 提案カードに「お誘いを送る」ボタン: 候補日の詳細をLINE等で共有可能
+- 提案カードの「お誘いを送る」に送信先選択機能: チャット投稿 / アンケート作成 / 外部共有の3択
 
 ### Changed
 - 提案タブ: 手動「候補日を検索」ボタンを廃止し、タブ表示時に自動で候補日を生成するように変更


### PR DESCRIPTION
## Summary

- 「お誘いを送る」ボタンをタップすると送信先選択ボトムシートを表示
- 3つの送信先:
  - **チャットに送る**: `chatMessagesProvider` でグループチャットにお誘いメッセージを投稿
  - **アンケートを作る**: `localPollsProvider` で「参加できる？」の投票を自動作成（参加OK/微妙…/不参加、前日締切）
  - **LINEなどで共有**: 従来の `share_plus` による外部シェア

Closes #41

## 変更ファイル
- `lib/features/suggestion/presentation/suggestions_tab.dart` — `_InviteDestinationSheet` + `_DestinationTile` 追加、`_sendInvite` を選択シートに変更
- `CHANGELOG.md`

## UI構成

```
BottomSheet
├── ドラッグハンドル
├── タイトル「お誘いを送る」+ 日付・アクティビティ表示
├── ListTile: チャットに送る (chat_bubble_outline / primary)
├── ListTile: アンケートを作る (poll_outlined / warning)
└── ListTile: LINEなどで共有 (share_outlined / success)
```

## Test plan

- [ ] `flutter analyze` — エラー0件
- [ ] カード「お誘いを送る」→ 送信先選択シート表示
- [ ] 「チャットに送る」→ チャットにメッセージ投稿 + SnackBar確認
- [ ] 「アンケートを作る」→ 投票作成 + SnackBar確認
- [ ] 「LINEなどで共有」→ 外部シェアシート表示
- [ ] 各アクション後にボトムシートが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)