### PR TITLE
fix(#45): お誘い送信完了表示 + デモ通知データ追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - 提案タブ: 手動「候補日を検索」ボタンを廃止し、タブ表示時に自動で候補日を生成するように変更
+- デモモード: チャット・投票・ToDoに初期デモデータを追加（通知バッジが起動時から表示される）
+
+### Fixed
+- お誘い送信後の完了SnackBarが表示されない問題を修正（bottom sheet の context 無効化が原因）
 - デモモード: 天気予報の地域デフォルトを福岡市に設定（設定画面から変更可能）
 
 - お問い合わせ画面 (ContactScreen): カテゴリ選択・件名・本文のフォーム付き問い合わせ機能

--- a/lib/features/chat/presentation/providers/chat_providers.dart
+++ b/lib/features/chat/presentation/providers/chat_providers.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/constants/demo_data.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/models/chat_message.dart';
 import 'package:uuid/uuid.dart';
 
@@ -40,7 +42,59 @@ class ChatMessagesNotifier extends Notifier<Map<String, List<ChatMessage>>> {
   static const _uuid = Uuid();
 
   @override
-  Map<String, List<ChatMessage>> build() => {};
+  Map<String, List<ChatMessage>> build() {
+    final authState = ref.watch(authNotifierProvider);
+    if (authState.isDemo) {
+      return _demoMessages();
+    }
+    return {};
+  }
+
+  static Map<String, List<ChatMessage>> _demoMessages() {
+    final now = DateTime.now();
+    return {
+      DemoData.demoGroupId: [
+        ChatMessage(
+          id: 'demo-msg-1',
+          groupId: DemoData.demoGroupId,
+          userId: 'demo-user-a',
+          displayName: 'あかり',
+          content: '今週末ひまな人いる？🙌',
+          readBy: const ['demo-user-a'],
+          createdAt: now.subtract(const Duration(hours: 2)),
+        ),
+        ChatMessage(
+          id: 'demo-msg-2',
+          groupId: DemoData.demoGroupId,
+          userId: 'demo-user-b',
+          displayName: 'けんた',
+          content: '土曜なら空いてるよ！',
+          readBy: const ['demo-user-b'],
+          createdAt: now.subtract(const Duration(hours: 1, minutes: 45)),
+        ),
+        ChatMessage(
+          id: 'demo-msg-3',
+          groupId: DemoData.demoGroupId,
+          userId: 'demo-user-c',
+          displayName: 'みく',
+          content: '私も土曜OK！ランチ行こうよ🍔',
+          readBy: const ['demo-user-c'],
+          createdAt: now.subtract(const Duration(hours: 1, minutes: 30)),
+        ),
+      ],
+      DemoData.demoGroupId2: [
+        ChatMessage(
+          id: 'demo-msg-4',
+          groupId: DemoData.demoGroupId2,
+          userId: 'demo-user-d',
+          displayName: 'そうた',
+          content: '来週のシフト出した？',
+          readBy: const ['demo-user-d'],
+          createdAt: now.subtract(const Duration(minutes: 30)),
+        ),
+      ],
+    };
+  }
 
   /// Send a new message to a group chat.
   void sendMessage({

--- a/lib/features/group/presentation/providers/poll_providers.dart
+++ b/lib/features/group/presentation/providers/poll_providers.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/constants/demo_data.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/models/poll.dart';
 import 'package:uuid/uuid.dart';
 
@@ -16,7 +18,49 @@ class PollsNotifier extends Notifier<Map<String, List<Poll>>> {
   static const _uuid = Uuid();
 
   @override
-  Map<String, List<Poll>> build() => {};
+  Map<String, List<Poll>> build() {
+    final authState = ref.watch(authNotifierProvider);
+    if (authState.isDemo) {
+      return _demoPolls();
+    }
+    return {};
+  }
+
+  static Map<String, List<Poll>> _demoPolls() {
+    final now = DateTime.now();
+    return {
+      DemoData.demoGroupId: [
+        Poll(
+          id: 'demo-poll-1',
+          groupId: DemoData.demoGroupId,
+          createdBy: 'demo-user-a',
+          creatorName: 'あかり',
+          question: '今週末ランチどこ行く？',
+          options: [
+            const PollOption(
+              id: 'demo-poll-opt-1',
+              text: 'ハンバーガー',
+              voterIds: ['demo-user-a', 'demo-user-b'],
+              voterNames: ['あかり', 'けんた'],
+            ),
+            const PollOption(
+              id: 'demo-poll-opt-2',
+              text: 'パスタ',
+              voterIds: ['demo-user-c'],
+              voterNames: ['みく'],
+            ),
+            const PollOption(
+              id: 'demo-poll-opt-3',
+              text: 'ラーメン',
+              voterIds: [],
+              voterNames: [],
+            ),
+          ],
+          createdAt: now.subtract(const Duration(hours: 3)),
+        ),
+      ],
+    };
+  }
 
   /// Create a new poll in a group.
   ///

--- a/lib/features/group/presentation/providers/todo_providers.dart
+++ b/lib/features/group/presentation/providers/todo_providers.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/core/constants/demo_data.dart';
+import 'package:himatch/features/auth/providers/auth_providers.dart';
 import 'package:himatch/models/todo_item.dart';
 import 'package:uuid/uuid.dart';
 
@@ -16,7 +18,38 @@ class TodosNotifier extends Notifier<Map<String, List<TodoItem>>> {
   static const _uuid = Uuid();
 
   @override
-  Map<String, List<TodoItem>> build() => {};
+  Map<String, List<TodoItem>> build() {
+    final authState = ref.watch(authNotifierProvider);
+    if (authState.isDemo) {
+      return _demoTodos();
+    }
+    return {};
+  }
+
+  static Map<String, List<TodoItem>> _demoTodos() {
+    final now = DateTime.now();
+    return {
+      DemoData.demoGroupId: [
+        TodoItem(
+          id: 'demo-todo-1',
+          groupId: DemoData.demoGroupId,
+          title: 'お店を予約する',
+          createdBy: 'demo-user-a',
+          assignedTo: 'local-user',
+          assignedName: 'あなた',
+          dueDate: now.add(const Duration(days: 3)),
+          createdAt: now.subtract(const Duration(hours: 2)),
+        ),
+        TodoItem(
+          id: 'demo-todo-2',
+          groupId: DemoData.demoGroupId,
+          title: '集合場所を決める',
+          createdBy: 'demo-user-b',
+          createdAt: now.subtract(const Duration(hours: 1)),
+        ),
+      ],
+    };
+  }
 
   /// Add a new todo item to a group.
   ///


### PR DESCRIPTION
## Summary
- お誘い送信後に SnackBar（緑背景 + チェックアイコン）が正しく表示されるよう修正
- デモモードにチャット・投票・ToDoの初期データを追加し、通知バッジが起動時から機能する

## 修正内容

### SnackBar 表示修正
- `_InviteDestinationSheet` が `Navigator.pop(context, result)` で送信先を返す方式に変更
- 親の `_SuggestionTile._sendInvite()` が返り値を受けて action + SnackBar を実行
- これにより bottom sheet の context 無効化問題を解消

### デモ通知データ
- `ChatMessagesNotifier`: デモモード時に他メンバーからの未読メッセージ 4件を初期表示
- `PollsNotifier`: 未投票のアンケート 1件（「今週末ランチどこ行く？」）
- `TodosNotifier`: 未完了タスク 2件（「お店を予約する」「集合場所を決める」）

## Test plan
- [ ] 提案カード → お誘いを送る → チャット → 緑の「送信しました」SnackBar が表示される
- [ ] 提案カード → お誘いを送る → アンケート → 緑の「作成しました」SnackBar が表示される
- [ ] デモモード起動時にグループタブのバッジが表示されている
- [ ] グループ詳細のチャット/ToDo/投票ボタンにバッジが表示されている
- [ ] `flutter analyze` エラーなし

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)