### PR TITLE
fix(#49): テスト修正・WidgetRef修正・dart fix・セキュリティ強化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ dist/
 .env.production
 *.env
 
+# Firebase / Google Services (contains API keys)
+google-services.json
+GoogleService-Info.plist
+
 # IDE
 .idea/
 .vscode/

--- a/lib/core/utils/rrule_parser.dart
+++ b/lib/core/utils/rrule_parser.dart
@@ -213,7 +213,7 @@ class RRuleParser {
       final y = until.year.toString().padLeft(4, '0');
       final m = until.month.toString().padLeft(2, '0');
       final d = until.day.toString().padLeft(2, '0');
-      parts.add('UNTIL=${y}${m}${d}T235959Z');
+      parts.add('UNTIL=$y$m${d}T235959Z');
     }
 
     return parts.join(';');
@@ -236,14 +236,14 @@ class RRuleParser {
         if (interval == 1) {
           buffer.write('毎日');
         } else {
-          buffer.write('${interval}日ごと');
+          buffer.write('$interval日ごと');
         }
 
       case 'WEEKLY':
         if (interval == 1) {
           buffer.write('毎週');
         } else {
-          buffer.write('${interval}週間ごと');
+          buffer.write('$interval週間ごと');
         }
         if (byDay.isNotEmpty) {
           final dayNames = byDay.map((d) {
@@ -261,7 +261,7 @@ class RRuleParser {
         if (interval == 1) {
           buffer.write('毎月');
         } else {
-          buffer.write('${interval}ヶ月ごと');
+          buffer.write('$intervalヶ月ごと');
         }
         if (byDay.isNotEmpty) {
           final dayNames = byDay.map((d) {
@@ -278,7 +278,7 @@ class RRuleParser {
         if (interval == 1) {
           buffer.write('毎年');
         } else {
-          buffer.write('${interval}年ごと');
+          buffer.write('$interval年ごと');
         }
     }
 

--- a/lib/features/booking/presentation/booking_screen.dart
+++ b/lib/features/booking/presentation/booking_screen.dart
@@ -406,7 +406,7 @@ class _BookingDetailSheet extends StatelessWidget {
                 shrinkWrap: true,
                 padding: const EdgeInsets.all(16),
                 itemCount: page.bookings.length,
-                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                separatorBuilder: (_, _) => const SizedBox(height: 8),
                 itemBuilder: (context, index) {
                   final booking = page.bookings[index];
                   return _BookingTile(

--- a/lib/features/chat/presentation/chat_screen.dart
+++ b/lib/features/chat/presentation/chat_screen.dart
@@ -265,7 +265,7 @@ class _MessageBubble extends StatelessWidget {
                               width: 200,
                               height: 150,
                               fit: BoxFit.cover,
-                              errorBuilder: (_, __, ___) => Container(
+                              errorBuilder: (_, _, _) => Container(
                                 width: 200,
                                 height: 150,
                                 color: AppColors.surfaceVariant,

--- a/lib/features/expense/presentation/expense_screen.dart
+++ b/lib/features/expense/presentation/expense_screen.dart
@@ -232,7 +232,7 @@ class _ExpenseScreenState extends ConsumerState<ExpenseScreen> {
 
                 // Paid by picker
                 DropdownButtonFormField<String>(
-                  value: paidBy,
+                  initialValue: paidBy,
                   decoration: const InputDecoration(labelText: '支払った人'),
                   items: members.map((m) {
                     final name = m.nickname ??
@@ -261,7 +261,7 @@ class _ExpenseScreenState extends ConsumerState<ExpenseScreen> {
 
                 // Split type
                 DropdownButtonFormField<String>(
-                  value: splitType,
+                  initialValue: splitType,
                   decoration: const InputDecoration(labelText: '割り方'),
                   items: const [
                     DropdownMenuItem(

--- a/lib/features/group/presentation/activity_feed_screen.dart
+++ b/lib/features/group/presentation/activity_feed_screen.dart
@@ -122,7 +122,7 @@ class ActivityFeedScreen extends ConsumerWidget {
               child: ListView.separated(
                 padding: const EdgeInsets.all(16),
                 itemCount: activities.length,
-                separatorBuilder: (_, __) => const Divider(height: 1),
+                separatorBuilder: (_, _) => const Divider(height: 1),
                 itemBuilder: (context, index) {
                   final activity = activities[index];
                   return _ActivityTile(

--- a/lib/features/group/presentation/album_screen.dart
+++ b/lib/features/group/presentation/album_screen.dart
@@ -276,7 +276,7 @@ class _PhotoGridItem extends StatelessWidget {
             child: Image.network(
               photo.thumbnailUrl ?? photo.imageUrl,
               fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) => Container(
+              errorBuilder: (_, _, _) => Container(
                 color: AppColors.surfaceVariant,
                 child: const Icon(Icons.broken_image, color: AppColors.textHint),
               ),
@@ -357,7 +357,7 @@ class _FullScreenPhotoView extends ConsumerWidget {
                 child: Image.network(
                   photo.imageUrl,
                   fit: BoxFit.contain,
-                  errorBuilder: (_, __, ___) => const Icon(
+                  errorBuilder: (_, _, _) => const Icon(
                     Icons.broken_image,
                     color: Colors.white54,
                     size: 64,

--- a/lib/features/group/presentation/board_screen.dart
+++ b/lib/features/group/presentation/board_screen.dart
@@ -293,7 +293,7 @@ class _PostCardState extends ConsumerState<_PostCard> {
                     child: ListView.separated(
                       scrollDirection: Axis.horizontal,
                       itemCount: post.imageUrls.length,
-                      separatorBuilder: (_, __) => const SizedBox(width: 8),
+                      separatorBuilder: (_, _) => const SizedBox(width: 8),
                       itemBuilder: (_, i) => ClipRRect(
                         borderRadius: BorderRadius.circular(8),
                         child: Image.network(
@@ -301,7 +301,7 @@ class _PostCardState extends ConsumerState<_PostCard> {
                           height: 160,
                           width: 160,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) => Container(
+                          errorBuilder: (_, _, _) => Container(
                             height: 160,
                             width: 160,
                             color: AppColors.surfaceVariant,

--- a/lib/features/group/presentation/groups_tab.dart
+++ b/lib/features/group/presentation/groups_tab.dart
@@ -16,7 +16,7 @@ class GroupsTab extends ConsumerWidget {
     final groups = ref.watch(localGroupsProvider);
 
     return Scaffold(
-      body: groups.isEmpty ? _EmptyState(ref: ref) : _GroupList(groups: groups),
+      body: groups.isEmpty ? const _EmptyState() : _GroupList(groups: groups),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showCreateDialog(context, ref),
         backgroundColor: AppColors.primary,
@@ -42,13 +42,11 @@ class GroupsTab extends ConsumerWidget {
   }
 }
 
-class _EmptyState extends StatelessWidget {
-  final WidgetRef ref;
-
-  const _EmptyState({required this.ref});
+class _EmptyState extends ConsumerWidget {
+  const _EmptyState();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
@@ -80,7 +78,7 @@ class _EmptyState extends StatelessWidget {
             ),
             const SizedBox(height: 32),
             OutlinedButton.icon(
-              onPressed: () => _showJoinDialog(context),
+              onPressed: () => _showJoinDialog(context, ref),
               icon: const Icon(Icons.login),
               label: const Text('招待コードで参加'),
               style: OutlinedButton.styleFrom(
@@ -95,7 +93,7 @@ class _EmptyState extends StatelessWidget {
     );
   }
 
-  Future<void> _showJoinDialog(BuildContext context) async {
+  Future<void> _showJoinDialog(BuildContext context, WidgetRef ref) async {
     final code = await showDialog<String>(
       context: context,
       builder: (_) => const JoinGroupDialog(),

--- a/lib/features/group/presentation/poll_screen.dart
+++ b/lib/features/group/presentation/poll_screen.dart
@@ -165,7 +165,7 @@ class _PollScreenState extends ConsumerState<PollScreen> {
                 SwitchListTile(
                   title: const Text('複数選択', style: TextStyle(fontSize: 14)),
                   value: isMultiSelect,
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                   contentPadding: EdgeInsets.zero,
                   onChanged: (v) => setDialogState(() => isMultiSelect = v),
                 ),
@@ -174,7 +174,7 @@ class _PollScreenState extends ConsumerState<PollScreen> {
                 SwitchListTile(
                   title: const Text('匿名投票', style: TextStyle(fontSize: 14)),
                   value: isAnonymous,
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                   contentPadding: EdgeInsets.zero,
                   onChanged: (v) => setDialogState(() => isAnonymous = v),
                 ),
@@ -412,7 +412,7 @@ class _PollCard extends ConsumerWidget {
                             tween: Tween(begin: 0, end: fraction),
                             duration: const Duration(milliseconds: 400),
                             curve: Curves.easeOut,
-                            builder: (_, value, __) =>
+                            builder: (_, value, _) =>
                                 LinearProgressIndicator(
                               value: value,
                               minHeight: 6,

--- a/lib/features/group/presentation/providers/group_providers.dart
+++ b/lib/features/group/presentation/providers/group_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:himatch/core/constants/demo_data.dart';
 import 'package:himatch/models/group.dart';
@@ -78,10 +80,10 @@ class LocalGroupsNotifier extends Notifier<List<Group>> {
   }
 
   String _generateInviteCode() {
-    final random = DateTime.now().microsecondsSinceEpoch;
+    final random = Random.secure();
     return List.generate(
       8,
-      (i) => _inviteChars[(random + i * 37) % _inviteChars.length],
+      (_) => _inviteChars[random.nextInt(_inviteChars.length)],
     ).join();
   }
 }

--- a/lib/features/group/presentation/todo_list_screen.dart
+++ b/lib/features/group/presentation/todo_list_screen.dart
@@ -204,7 +204,7 @@ class _TodoListScreenState extends ConsumerState<TodoListScreen> {
 
                 // Assignee picker
                 DropdownButtonFormField<String>(
-                  value: selectedMemberId,
+                  initialValue: selectedMemberId,
                   decoration: const InputDecoration(
                     labelText: '担当者',
                   ),

--- a/lib/features/profile/presentation/notification_settings_screen.dart
+++ b/lib/features/profile/presentation/notification_settings_screen.dart
@@ -172,7 +172,7 @@ class NotificationSettingsScreen extends ConsumerWidget {
                             return s.copyWith(mutedGroupIds: updated);
                           });
                         },
-                        activeColor: AppColors.primary,
+                        activeThumbColor: AppColors.primary,
                         secondary: CircleAvatar(
                           radius: 18,
                           backgroundColor:
@@ -283,7 +283,7 @@ class _NotificationToggle extends StatelessWidget {
       ),
       value: value,
       onChanged: onChanged,
-      activeColor: AppColors.primary,
+      activeThumbColor: AppColors.primary,
       secondary: Icon(icon, color: AppColors.textSecondary),
     );
   }

--- a/lib/features/profile/presentation/theme_settings_screen.dart
+++ b/lib/features/profile/presentation/theme_settings_screen.dart
@@ -195,7 +195,7 @@ class _DarkModeToggle extends StatelessWidget {
         ),
         value: isDarkMode,
         onChanged: onChanged,
-        activeColor: AppColors.primary,
+        activeThumbColor: AppColors.primary,
         secondary: Icon(
           isDarkMode ? Icons.dark_mode : Icons.light_mode,
           color: isDarkMode ? AppColors.primary : AppColors.warning,

--- a/lib/features/schedule/presentation/calendar_sync_settings_screen.dart
+++ b/lib/features/schedule/presentation/calendar_sync_settings_screen.dart
@@ -203,7 +203,7 @@ class CalendarSyncSettingsScreen extends ConsumerWidget {
                   subtitle: const Text('外部カレンダーの予定を取り込む',
                       style: TextStyle(fontSize: 12)),
                   value: syncState.importEnabled,
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                   onChanged: (v) {
                     ref.read(calendarSyncProvider.notifier).toggleImport(v);
                   },
@@ -215,7 +215,7 @@ class CalendarSyncSettingsScreen extends ConsumerWidget {
                   subtitle: const Text('ヒマッチの予定を外部カレンダーに反映',
                       style: TextStyle(fontSize: 12)),
                   value: syncState.exportEnabled,
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                   onChanged: (v) {
                     ref.read(calendarSyncProvider.notifier).toggleExport(v);
                   },
@@ -330,7 +330,7 @@ class CalendarSyncSettingsScreen extends ConsumerWidget {
           ),
         ),
         value: value,
-        activeColor: AppColors.primary,
+        activeThumbColor: AppColors.primary,
         onChanged: onChanged,
       ),
     );

--- a/lib/features/schedule/presentation/providers/calendar_providers.dart
+++ b/lib/features/schedule/presentation/providers/calendar_providers.dart
@@ -65,11 +65,11 @@ class LocalSchedulesNotifier extends Notifier<List<Schedule>> {
       final endParts = endTime.split(':');
       scheduleStart = DateTime(
         date.year, date.month, date.day,
-        int.parse(startParts[0]), int.parse(startParts[1]),
+        int.tryParse(startParts[0]) ?? 0, int.tryParse(startParts.length > 1 ? startParts[1] : '0') ?? 0,
       );
       scheduleEnd = DateTime(
         date.year, date.month, date.day,
-        int.parse(endParts[0]), int.parse(endParts[1]),
+        int.tryParse(endParts[0]) ?? 0, int.tryParse(endParts.length > 1 ? endParts[1] : '0') ?? 0,
       );
       // 夜勤等: 終了 < 開始の場合は翌日扱い
       if (scheduleEnd.isBefore(scheduleStart)) {

--- a/lib/features/schedule/presentation/template_screen.dart
+++ b/lib/features/schedule/presentation/template_screen.dart
@@ -531,7 +531,7 @@ class _TemplateEditorScreenState extends State<_TemplateEditorScreen> {
               value: _isAllDay,
               onChanged: (v) => setState(() => _isAllDay = v),
               contentPadding: EdgeInsets.zero,
-              activeColor: AppColors.primary,
+              activeThumbColor: AppColors.primary,
             ),
 
             // Time fields

--- a/lib/features/shift/presentation/shift_pattern_screen.dart
+++ b/lib/features/shift/presentation/shift_pattern_screen.dart
@@ -224,7 +224,7 @@ class ShiftPatternScreen extends ConsumerWidget {
                 Navigator.pop(ctx);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
-                    content: Text('${pattern.name}を${days}日間適用しました'),
+                    content: Text('${pattern.name}を$days日間適用しました'),
                   ),
                 );
               },

--- a/lib/features/suggestion/presentation/providers/suggestion_providers.dart
+++ b/lib/features/suggestion/presentation/providers/suggestion_providers.dart
@@ -35,12 +35,17 @@ class LocalSuggestionsNotifier extends Notifier<List<Suggestion>> {
     }
 
     // Fetch weather data using resolved coordinates (graceful: empty map on failure)
-    final weatherService = ref.read(weatherServiceProvider);
-    final coords = await ref.read(resolvedWeatherCoordsProvider.future);
-    final weatherData = await weatherService.fetchForecast(
-      latitude: coords.latitude,
-      longitude: coords.longitude,
-    );
+    Map<DateTime, WeatherSummary> weatherData = {};
+    try {
+      final weatherService = ref.read(weatherServiceProvider);
+      final coords = await ref.read(resolvedWeatherCoordsProvider.future);
+      weatherData = await weatherService.fetchForecast(
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+      );
+    } catch (_) {
+      // Weather fetch failed — continue with empty weather data
+    }
 
     final allSuggestions = <Suggestion>[];
 

--- a/lib/features/suggestion/presentation/share_card_screen.dart
+++ b/lib/features/suggestion/presentation/share_card_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:himatch/core/theme/app_theme.dart';
 

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,6 +1,6 @@
 import 'package:uuid/uuid.dart';
 
-import '../models/chat_message.dart';
+import 'package:himatch/models/chat_message.dart';
 
 /// Chat service with local state management.
 ///

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -6,7 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 
-import '../models/schedule.dart';
+import 'package:himatch/models/schedule.dart';
 import 'salary_calculator.dart';
 
 /// Export schedules and salary data to various formats.

--- a/lib/services/learning_engine.dart
+++ b/lib/services/learning_engine.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import '../models/suggestion.dart';
+import 'package:himatch/models/suggestion.dart';
 
 /// Learn from confirmed suggestions to improve future scoring.
 ///

--- a/lib/services/salary_calculator.dart
+++ b/lib/services/salary_calculator.dart
@@ -1,5 +1,5 @@
-import '../models/schedule.dart';
-import '../models/workplace.dart';
+import 'package:himatch/models/schedule.dart';
+import 'package:himatch/models/workplace.dart';
 import 'holiday_service.dart';
 
 /// Calculate salary from shift schedules.
@@ -285,7 +285,7 @@ class SalaryReport {
   static String formatMinutes(int minutes) {
     final h = minutes ~/ 60;
     final m = minutes % 60;
-    return m > 0 ? '${h}時間${m}分' : '${h}時間';
+    return m > 0 ? '$h時間$m分' : '$h時間';
   }
 
   /// Format yen amount with comma separator.
@@ -296,7 +296,7 @@ class SalaryReport {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return '${buffer}円';
+    return '$buffer円';
   }
 }
 

--- a/lib/services/share_card_generator.dart
+++ b/lib/services/share_card_generator.dart
@@ -4,7 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-import '../models/suggestion.dart';
+import 'package:himatch/models/suggestion.dart';
 
 /// Generate shareable image cards for confirmed plans.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,16 +27,10 @@ dependencies:
   # UI
   table_calendar: ^3.2.0
   flutter_animate: ^4.5.2
-  cached_network_image: ^3.4.1
 
   # HTTP
   http: ^1.3.0
 
-  # Calendar Sync
-  device_calendar: ^4.3.3
-
-  # Notifications
-  flutter_local_notifications: ^18.0.1
 
   # Export
   pdf: ^3.11.2
@@ -48,12 +42,6 @@ dependencies:
 
   # Media
   image_picker: ^1.1.2
-
-  # Widget
-  home_widget: ^0.7.0
-
-  # URL
-  url_launcher: ^6.3.1
 
   # ユーティリティ
   intl: ^0.20.0

--- a/test/features/group/group_providers_test.dart
+++ b/test/features/group/group_providers_test.dart
@@ -14,9 +14,11 @@ void main() {
   });
 
   group('LocalGroupsNotifier', () {
-    test('initial state is empty', () {
+    test('initial state has demo groups', () {
       final groups = container.read(localGroupsProvider);
-      expect(groups, isEmpty);
+      expect(groups, hasLength(2));
+      expect(groups[0].name, 'ゼミ3年');
+      expect(groups[1].name, 'バイト仲間');
     });
 
     test('createGroup adds a group', () {
@@ -24,10 +26,10 @@ void main() {
       notifier.createGroup(name: 'テストグループ');
 
       final groups = container.read(localGroupsProvider);
-      expect(groups, hasLength(1));
-      expect(groups.first.name, 'テストグループ');
-      expect(groups.first.inviteCode, hasLength(8));
-      expect(groups.first.createdBy, 'local-user');
+      expect(groups, hasLength(3));
+      expect(groups.last.name, 'テストグループ');
+      expect(groups.last.inviteCode, hasLength(8));
+      expect(groups.last.createdBy, 'local-user');
     });
 
     test('createGroup with description', () {
@@ -38,7 +40,7 @@ void main() {
       );
 
       final groups = container.read(localGroupsProvider);
-      expect(groups.first.description, '毎月の飲み会メンバー');
+      expect(groups.last.description, '毎月の飲み会メンバー');
     });
 
     test('createGroup auto-adds creator as owner', () {
@@ -56,12 +58,12 @@ void main() {
       final notifier = container.read(localGroupsProvider.notifier);
       final group = notifier.createGroup(name: 'グループ');
 
-      expect(container.read(localGroupsProvider), hasLength(1));
+      expect(container.read(localGroupsProvider), hasLength(3));
       expect(container.read(localGroupMembersProvider)[group.id], hasLength(1));
 
       notifier.removeGroup(group.id);
 
-      expect(container.read(localGroupsProvider), isEmpty);
+      expect(container.read(localGroupsProvider), hasLength(2));
       expect(container.read(localGroupMembersProvider)[group.id], isNull);
     });
 
@@ -116,14 +118,16 @@ void main() {
       notifier.createGroup(name: 'グループ2');
       notifier.createGroup(name: 'グループ3');
 
-      expect(container.read(localGroupsProvider), hasLength(3));
+      expect(container.read(localGroupsProvider), hasLength(5));
     });
   });
 
   group('LocalGroupMembersNotifier', () {
-    test('initial state is empty map', () {
+    test('initial state has demo members', () {
       final members = container.read(localGroupMembersProvider);
-      expect(members, isEmpty);
+      expect(members, isNotEmpty);
+      expect(members['demo-group-1'], hasLength(4));
+      expect(members['demo-group-2'], hasLength(3));
     });
 
     test('addMember creates entry for group', () {


### PR DESCRIPTION
## Summary
- テスト6件の期待値をデモデータ初期状態に合わせて修正
- `_EmptyState` の WidgetRef フィールド保持問題を修正
- `dart fix --apply` で37件の deprecated API + スタイル修正
- 未使用パッケージ5件削除（device_calendar, flutter_local_notifications等）
- 招待コード生成を `Random.secure()` に変更
- `refreshSuggestions` に try-catch エラーハンドリング追加
- `addShiftSchedule` の `int.parse` → `int.tryParse` バリデーション
- 相対importを `package:himatch/` に統一
- `.gitignore` に `google-services.json` 等追加

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test` 全53テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)