### PR TITLE
fix(#50): iOS/Android カメラ・写真パーミッション追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <application
         android:label="himatch"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,6 +47,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>グループアルバムに写真を撮影して投稿するために使用します</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>グループアルバムに写真を選択して投稿するために使用します</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>現在地の天気予報を表示するために位置情報を使用します。</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
## Summary
- iOS `Info.plist` に `NSCameraUsageDescription` / `NSPhotoLibraryUsageDescription` 追加
- Android `AndroidManifest.xml` に `CAMERA` / `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE` 追加

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)