### PR TITLE
fix(#53): Provider.family に autoDispose 追加

### DIFF
--- a/lib/features/shift/presentation/providers/salary_providers.dart
+++ b/lib/features/shift/presentation/providers/salary_providers.dart
@@ -90,7 +90,7 @@ class SalaryReport {
 /// Uses the workplace's closing day to determine the pay period.
 /// For example, closingDay=25 means the period is the 26th of the previous
 /// month through the 25th of the current month.
-final monthlySalaryProvider = Provider.family<SalaryReport?,
+final monthlySalaryProvider = Provider.autoDispose.family<SalaryReport?,
     ({String workplaceId, int year, int month})>((ref, params) {
   final workplaces = ref.watch(workplacesProvider);
   final schedules = ref.watch(localSchedulesProvider);
@@ -146,7 +146,7 @@ final monthlySalaryProvider = Provider.family<SalaryReport?,
 ///
 /// Sums monthly salary reports for all 12 months of the given year.
 final yearlySalaryProvider =
-    Provider.family<int, ({String workplaceId, int year})>((ref, params) {
+    Provider.autoDispose.family<int, ({String workplaceId, int year})>((ref, params) {
   int total = 0;
   for (int month = 1; month <= 12; month++) {
     final report = ref.watch(monthlySalaryProvider((
@@ -186,7 +186,7 @@ class TaxWallWarning {
 ///
 /// Returns warnings for each tax threshold, indicating how close
 /// the user is to exceeding the limit.
-final taxWallWarningsProvider = Provider.family<List<TaxWallWarning>,
+final taxWallWarningsProvider = Provider.autoDispose.family<List<TaxWallWarning>,
     ({String workplaceId, int year})>((ref, params) {
   final yearlyTotal = ref.watch(yearlySalaryProvider((
     workplaceId: params.workplaceId,

--- a/lib/features/suggestion/presentation/providers/weather_providers.dart
+++ b/lib/features/suggestion/presentation/providers/weather_providers.dart
@@ -20,7 +20,7 @@ final weatherForecastProvider =
 
 /// Look up weather for a specific date.
 final weatherForDateProvider =
-    Provider.family<WeatherSummary?, DateTime>((ref, date) {
+    Provider.autoDispose.family<WeatherSummary?, DateTime>((ref, date) {
   final forecastAsync = ref.watch(weatherForecastProvider);
   return forecastAsync.whenOrNull(
     data: (forecast) {

--- a/lib/providers/holiday_providers.dart
+++ b/lib/providers/holiday_providers.dart
@@ -7,7 +7,7 @@ final holidayServiceProvider = Provider<JapaneseHolidayService>((ref) {
 
 /// Look up holiday name for a specific date. Returns null if not a holiday.
 final holidayForDateProvider =
-    Provider.family<String?, DateTime>((ref, date) {
+    Provider.autoDispose.family<String?, DateTime>((ref, date) {
   final service = ref.read(holidayServiceProvider);
   return service.getHoliday(date);
 });


### PR DESCRIPTION
## Summary
- `holiday_providers.dart` / `weather_providers.dart` / `salary_providers.dart` の `.family` に `.autoDispose` 追加
- 画面離脱時のメモリリークを防止

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)