### PR TITLE
feat(#56): OAuth ディープリンク設定 + パスワード最小長変更

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Deep link for Supabase OAuth callback -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.skanglers.himatch"
+                      android:host="login-callback" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,6 +51,17 @@
 	<string>グループアルバムに写真を撮影して投稿するために使用します</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>グループアルバムに写真を選択して投稿するために使用します</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.skanglers.himatch</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>現在地の天気予報を表示するために位置情報を使用します。</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "com.skanglers.himatch://login-callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -172,7 +172,7 @@ enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
-minimum_password_length = 6
+minimum_password_length = 8
 # Passwords that do not meet the following requirements will be rejected as weak. Supported values
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
 password_requirements = ""


### PR DESCRIPTION
## Summary
- iOS `Info.plist` に `CFBundleURLSchemes` でディープリンク追加
- Android `AndroidManifest.xml` に `intent-filter` 追加
- Supabase `config.toml` に redirect URL 追加 + パスワード最小長 6→8

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)