### PR TITLE
perf(#61): LazyIndexedStack + カレンダー Provider 最適化

### DIFF
--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:himatch/features/group/presentation/groups_tab.dart';
 import 'package:himatch/features/suggestion/presentation/suggestions_tab.dart';
 import 'package:himatch/features/profile/presentation/profile_tab.dart';
 import 'package:himatch/features/group/presentation/providers/notification_providers.dart';
+import 'package:himatch/widgets/lazy_indexed_stack.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -41,7 +42,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
         ],
       ),
-      body: IndexedStack(
+      body: LazyIndexedStack(
         index: _selectedIndex,
         children: const [
           CalendarTab(),

--- a/lib/features/schedule/presentation/calendar_tab.dart
+++ b/lib/features/schedule/presentation/calendar_tab.dart
@@ -13,6 +13,7 @@ import 'package:himatch/features/schedule/presentation/widgets/shift_badge.dart'
 import 'package:himatch/features/schedule/presentation/widgets/shift_type_editor_sheet.dart';
 import 'package:himatch/features/suggestion/presentation/providers/weather_providers.dart';
 import 'package:himatch/providers/holiday_providers.dart';
+import 'package:himatch/features/schedule/presentation/providers/month_data_providers.dart';
 import 'package:himatch/features/schedule/presentation/widgets/week_view.dart';
 import 'package:himatch/features/schedule/presentation/widgets/day_view.dart';
 import 'package:himatch/features/schedule/presentation/widgets/quick_input_field.dart';
@@ -49,6 +50,11 @@ class _CalendarTabState extends ConsumerState<CalendarTab> {
     final shiftTypeMap = ref.watch(shiftTypeMapProvider);
     final selectedDaySchedules = _getSchedulesForDay(_selectedDay, schedules);
 
+    // Month-level batch data for calendar cells (avoids per-cell .family providers)
+    final monthKey = DateTime(_focusedDay.year, _focusedDay.month, 1);
+    final weatherMap = ref.watch(monthWeatherProvider(monthKey));
+    final holidayMap = ref.watch(monthHolidayProvider(monthKey));
+
     return Scaffold(
       body: Column(
         children: [
@@ -82,8 +88,8 @@ class _CalendarTabState extends ConsumerState<CalendarTab> {
                   isSelected: false,
                   isOutside: false,
                   scheduleCount: events.length,
-                  weather: ref.watch(weatherForDateProvider(key)),
-                  holidayName: ref.watch(holidayForDateProvider(key)),
+                  weather: weatherMap[key],
+                  holidayName: holidayMap[key],
                   shiftTypeMap: shiftTypeMap,
                   events: events,
                 );
@@ -97,8 +103,8 @@ class _CalendarTabState extends ConsumerState<CalendarTab> {
                   isSelected: isSameDay(_selectedDay, day),
                   isOutside: false,
                   scheduleCount: events.length,
-                  weather: ref.watch(weatherForDateProvider(key)),
-                  holidayName: ref.watch(holidayForDateProvider(key)),
+                  weather: weatherMap[key],
+                  holidayName: holidayMap[key],
                   shiftTypeMap: shiftTypeMap,
                   events: events,
                 );
@@ -112,8 +118,8 @@ class _CalendarTabState extends ConsumerState<CalendarTab> {
                   isSelected: true,
                   isOutside: false,
                   scheduleCount: events.length,
-                  weather: ref.watch(weatherForDateProvider(key)),
-                  holidayName: ref.watch(holidayForDateProvider(key)),
+                  weather: weatherMap[key],
+                  holidayName: holidayMap[key],
                   shiftTypeMap: shiftTypeMap,
                   events: events,
                 );

--- a/lib/features/schedule/presentation/providers/month_data_providers.dart
+++ b/lib/features/schedule/presentation/providers/month_data_providers.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:himatch/models/suggestion.dart';
+import 'package:himatch/features/suggestion/presentation/providers/weather_providers.dart';
+import 'package:himatch/providers/holiday_providers.dart';
+
+/// Pre-built weather map for an entire month, keyed by date-only DateTime.
+/// Calendar cells do a simple Map lookup instead of creating individual
+/// .family provider instances per cell.
+final monthWeatherProvider =
+    Provider.autoDispose.family<Map<DateTime, WeatherSummary>, DateTime>(
+  (ref, month) {
+    final forecastAsync = ref.watch(weatherForecastProvider);
+    return forecastAsync.whenOrNull(data: (forecast) => forecast) ?? {};
+  },
+);
+
+/// Pre-built holiday map for an entire month, keyed by date-only DateTime.
+final monthHolidayProvider =
+    Provider.autoDispose.family<Map<DateTime, String>, DateTime>(
+  (ref, month) {
+    final service = ref.read(holidayServiceProvider);
+    final result = <DateTime, String>{};
+    // Cover 6 weeks to handle overflow days shown in the calendar
+    final start = DateTime(month.year, month.month, 1).subtract(const Duration(days: 7));
+    final end = DateTime(month.year, month.month + 1, 0).add(const Duration(days: 14));
+    for (var d = start; !d.isAfter(end); d = d.add(const Duration(days: 1))) {
+      final key = DateTime(d.year, d.month, d.day);
+      final name = service.getHoliday(key);
+      if (name != null) {
+        result[key] = name;
+      }
+    }
+    return result;
+  },
+);

--- a/lib/widgets/lazy_indexed_stack.dart
+++ b/lib/widgets/lazy_indexed_stack.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+/// An [IndexedStack] variant that lazily builds children on first display.
+///
+/// Standard [IndexedStack] builds all children at once even if only one is
+/// visible. [LazyIndexedStack] defers each child's construction until the
+/// user first navigates to that index, reducing initial build cost.
+class LazyIndexedStack extends StatefulWidget {
+  final int index;
+  final List<Widget> children;
+
+  const LazyIndexedStack({
+    super.key,
+    required this.index,
+    required this.children,
+  });
+
+  @override
+  State<LazyIndexedStack> createState() => _LazyIndexedStackState();
+}
+
+class _LazyIndexedStackState extends State<LazyIndexedStack> {
+  late final List<bool> _activated;
+
+  @override
+  void initState() {
+    super.initState();
+    _activated = List.filled(widget.children.length, false);
+    _activated[widget.index] = true;
+  }
+
+  @override
+  void didUpdateWidget(LazyIndexedStack oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Mark newly selected index as activated
+    if (!_activated[widget.index]) {
+      _activated[widget.index] = true;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IndexedStack(
+      index: widget.index,
+      children: List.generate(widget.children.length, (i) {
+        if (_activated[i]) {
+          return widget.children[i];
+        }
+        return const SizedBox.shrink();
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- `LazyIndexedStack` ウィジェットで未表示タブの構築を遅延
- `monthWeatherProvider` / `monthHolidayProvider` で月単位バッチ取得
- セルごとの ~42個の `.family` Provider を Map lookup に置換

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test` 全53テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)