### PR TITLE
fix: AppBar 通知ボタンを NotificationSettingsScreen に接続

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- HomeScreen AppBar の通知ボタンが空実装（TODO）で機能していなかった問題を修正 → NotificationSettingsScreen に遷移するように接続
+
 ### Changed (Docs)
 - README.md を全面刷新: 全機能一覧・デザインシステム・セットアップ手順・テスト手順を追加
 

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -53,7 +53,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               child: const Icon(Icons.notifications_outlined),
             ),
             onPressed: () {
-              // TODO: Navigate to notifications
+              context.pushNamed(AppRoute.notificationSettings.name);
             },
           ),
           IconButton(


### PR DESCRIPTION
## Summary
- AppBar の通知ベルボタンが `// TODO` 空実装で何も起きなかった問題を修正
- `context.pushNamed(AppRoute.notificationSettings.name)` で通知設定画面に遷移するよう接続
- 設定ボタン（歯車アイコン）はテーマ設定画面への遷移が既に実装済みで問題なし

Closes #71

## Test plan
- [ ] AppBar の通知ベルをタップ → 通知設定画面が開くこと
- [ ] AppBar の設定ボタンをタップ → テーマ設定画面が開くこと
- [ ] 各設定画面から戻るボタンでホームに戻れること

🤖 Generated with [Claude Code](https://claude.com/claude-code)