### PR TITLE
fix: AppBar ボタンのナビゲーションを GoRouter 直接参照に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - HomeScreen AppBar の通知ボタンが空実装（TODO）で機能していなかった問題を修正 → NotificationSettingsScreen に遷移するように接続
+- HomeScreen AppBar のナビゲーションを context.pushNamed から ref.read(appRouterProvider).push に変更（GoRouter.of(context) の解決失敗を回避）
 
 ### Changed (Docs)
 - README.md を全面刷新: 全機能一覧・デザインシステム・セットアップ手順・テスト手順を追加

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:himatch/core/theme/app_theme.dart';
-import 'package:himatch/routing/app_routes.dart';
+import 'package:himatch/routing/app_router.dart';
 import 'package:himatch/features/schedule/presentation/calendar_tab.dart';
 import 'package:himatch/features/group/presentation/groups_tab.dart';
 import 'package:himatch/features/suggestion/presentation/suggestions_tab.dart';
@@ -53,13 +52,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               child: const Icon(Icons.notifications_outlined),
             ),
             onPressed: () {
-              context.pushNamed(AppRoute.notificationSettings.name);
+              ref.read(appRouterProvider).push('/settings/notifications');
             },
           ),
           IconButton(
             icon: const Icon(Icons.settings_outlined),
             onPressed: () {
-              context.pushNamed(AppRoute.themeSettings.name);
+              ref.read(appRouterProvider).push('/settings/theme');
             },
           ),
         ],


### PR DESCRIPTION
## Summary
- `context.pushNamed` が `GoRouter.of(context)` 経由で GoRouter を解決するが、HomeScreen の context からは正常に解決できなかった問題を修正
- `ref.read(appRouterProvider).push('/path')` に変更し、Riverpod から直接 GoRouter インスタンスを取得してナビゲーション
- 通知ボタン → `/settings/notifications` (NotificationSettingsScreen)
- 設定ボタン → `/settings/theme` (ThemeSettingsScreen)

Closes #71

## Root cause
`context.pushNamed(AppRoute.themeSettings.name)` は内部で `GoRouter.of(context)` を呼び出し、widget tree の InheritedGoRouter からルーターを取得する。HomeScreen は GoRouter の root route として構築されるが、web 環境でのルーター解決に問題があった可能性がある。Riverpod の `ref.read(appRouterProvider)` で直接ルーターインスタンスを取得することで確実に動作するよう修正。

## Test plan
- [ ] AppBar の通知ベルをタップ → 通知設定画面が開くこと
- [ ] AppBar の設定ボタンをタップ → テーマ設定画面が開くこと
- [ ] 各設定画面の戻るボタンでホームに戻れること
- [ ] ProfileTab からの同じ画面へのナビゲーションも引き続き動作すること
- [ ] `flutter test` 全53テストパス ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)